### PR TITLE
Fix attendance fetching and dashboard summary

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/README_attendance.md
+++ b/README_attendance.md
@@ -9,16 +9,19 @@ Este repositorio incluye el MVP para registrar asistencia diaria por salón.
    - Copia el contenido de `supabase/attendance.sql` y ejecútalo en tu proyecto.
    - Esto creará la tabla `attendance`, los índices, el trigger de `updated_at` y las políticas RLS necesarias.
 
-2. **Asignar maestras a salones**
-   - Usa la tabla `teacher_classroom` para vincular perfiles de maestras con sus salones.
-   - Cada registro debe incluir `teacher_id` (id del `user_profile` de la maestra) y `classroom_id`.
-   - Recuerda que las maestras solo podrán tomar asistencia en los salones que tengan asignados.
+2. **Configurar docentes y matrículas**
+   - En `teacher_classroom` registra cada maestra con los salones que puede atender (`teacher_id` = id del `user_profile`, `classroom_id`).
+   - En `enrollment` inscribe a cada estudiante en su salón (`student_id`, `classroom_id`, `school_id`). Estas filas son las que usa la app para mostrar a los alumnos.
 
-3. **Probar la interfaz**
+3. **Campos esperados en `student`**
+   - La interfaz lee `full_name` si existe y, en caso contrario, concatena `first_name` y `last_name`.
+   - Asegúrate de capturar también `date_of_birth` cuando esté disponible; se muestra en la vista de asistencia.
+
+4. **Probar la interfaz**
    - Inicia la aplicación (`npm run dev`).
    - Visita `/attendance` para registrar asistencia. Selecciona el salón y la fecha, marca los estados (P/A/R) y agrega notas si es necesario.
    - Usa el botón **Guardar asistencia** para almacenar los cambios. El botón **Exportar CSV** descarga el reporte diario para ese salón.
-   - La ruta `/debug/attendance` muestra información de depuración (rol, salones accesibles y resultado de una consulta ejemplo) para validar las políticas RLS.
+   - La ruta `/debug/attendance` muestra un JSON con el usuario autenticado, rol detectado, salones cargados, número de alumnos del salón seleccionado y el último error reportado por la pantalla de asistencia.
 
 ## Notas
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,112 +1,349 @@
+"use client";
+
 import Link from "next/link";
-import { redirect } from "next/navigation";
-import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import {
+  getClassroomsForUser,
+  getMyProfile,
+  getStudentDisplayName,
+  type AttendanceClassroom,
+  type AttendanceRole,
+  type TypedSupabaseClient,
+} from "@/lib/attendance/client";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
 import type { Database } from "@/types/database";
 
-export const dynamic = "force-dynamic";
+type AttendanceStatus = Database["public"]["Tables"]["attendance"]["Row"]["status"];
 
-type DashboardProfile = Pick<
-  Database["public"]["Tables"]["user_profile"]["Row"],
-  "id" | "display_name" | "role"
-> & {
+type DashboardProfileDetails = {
+  display_name: string | null;
   school: { name: string } | null;
 };
 
-type DashboardClassroom = Pick<Database["public"]["Tables"]["classroom"]["Row"], "id" | "name">;
+type ClassroomSummary = {
+  classroomId: string;
+  classroomName: string;
+  counts: Record<AttendanceStatus, number>;
+};
 
-type DashboardStudent = Pick<Database["public"]["Tables"]["student"]["Row"], "id" | "first_name" | "last_name">;
+type LatestAttendanceRow = {
+  id: string;
+  date: string;
+  status: AttendanceStatus | null;
+  classroomName: string;
+  studentName: string;
+};
 
-export default async function DashboardPage() {
-  const supabase = createServerSupabaseClient();
-  const {
-    data: { session }
-  } = await supabase.auth.getSession();
+function formatQueryError(query: string, error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `${query}: ${message}`;
+}
 
-  if (!session) {
-    redirect("/login");
-  }
+export default function DashboardPage() {
+  const supabase = useMemo(() => createClientSupabaseClient(), []);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+  const router = useRouter();
 
-  async function signOut() {
-    "use server";
-    const serverClient = createServerSupabaseClient();
-    await serverClient.auth.signOut();
-    redirect("/login");
-  }
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [role, setRole] = useState<AttendanceRole | null>(null);
+  const [profileDetails, setProfileDetails] = useState<DashboardProfileDetails | null>(null);
+  const [classrooms, setClassrooms] = useState<AttendanceClassroom[]>([]);
+  const [totalStudents, setTotalStudents] = useState<number>(0);
+  const [attendanceToday, setAttendanceToday] = useState<ClassroomSummary[]>([]);
+  const [latestAttendance, setLatestAttendance] = useState<LatestAttendanceRow[]>([]);
 
-  const { data: profile } = await supabase
-    .from("user_profile")
-    .select("id, display_name, role, school(name)")
-    .eq("id", session.user.id)
-    .maybeSingle<DashboardProfile>();
+  useEffect(() => {
+    let ignore = false;
 
-  const { data: classrooms } = await supabase
-    .from("classroom")
-    .select("id, name")
-    .order("name", { ascending: true })
-    .returns<DashboardClassroom[]>();
+    async function loadDashboard() {
+      setLoading(true);
+      setError(null);
 
-  const { data: students } = await supabase
-    .from("student")
-    .select("id, first_name, last_name")
-    .order("first_name", { ascending: true })
-    .returns<DashboardStudent[]>();
+      try {
+        const {
+          data: { session },
+          error: sessionError,
+        } = await supabase.auth.getSession();
+
+        if (sessionError) {
+          throw new Error(formatQueryError("auth.getSession", sessionError));
+        }
+
+        const user = session?.user ?? null;
+        if (!user) {
+          router.replace("/login");
+          return;
+        }
+
+        if (ignore) return;
+
+        const profileBasics = await getMyProfile(typedSupabase, user.id).catch((error) => {
+          throw new Error(formatQueryError("getMyProfile", error));
+        });
+
+        if (ignore) return;
+
+        if (!profileBasics) {
+          throw new Error("getMyProfile: No encontramos tu perfil.");
+        }
+
+        const currentRole = profileBasics.role ?? null;
+        setRole(currentRole);
+
+        const { data: profileRow, error: profileRowError } = await supabase
+          .from("user_profile")
+          .select("display_name, school:school_id (name)")
+          .eq("id", user.id)
+          .maybeSingle<DashboardProfileDetails>();
+
+        if (profileRowError) {
+          throw new Error(formatQueryError("user_profile.select", profileRowError));
+        }
+
+        if (ignore) return;
+
+        setProfileDetails(profileRow ?? null);
+
+        const accessibleClassrooms = await getClassroomsForUser(
+          typedSupabase,
+          currentRole,
+          profileBasics,
+        ).catch((error) => {
+          throw new Error(formatQueryError("getClassroomsForUser", error));
+        });
+
+        if (ignore) return;
+
+        setClassrooms(accessibleClassrooms);
+
+        const { count: studentsCount, error: studentsCountError } = await supabase
+          .from("student")
+          .select("id", { count: "exact", head: true });
+
+        if (studentsCountError) {
+          throw new Error(formatQueryError("student.count", studentsCountError));
+        }
+
+        if (ignore) return;
+
+        setTotalStudents(studentsCount ?? 0);
+
+        if (accessibleClassrooms.length > 0) {
+          const classroomIds = accessibleClassrooms.map((classroom) => classroom.id);
+          const today = new Date().toISOString().slice(0, 10);
+          const { data: attendanceRows, error: attendanceError } = await supabase
+            .from("attendance")
+            .select("classroom_id, status")
+            .eq("date", today)
+            .in("classroom_id", classroomIds);
+
+          if (attendanceError) {
+            if (attendanceError.code !== "42P01") {
+              throw new Error(formatQueryError("attendance.select", attendanceError));
+            }
+          }
+
+          if (ignore) return;
+
+          if (attendanceRows) {
+            const summaryMap = new Map<string, ClassroomSummary>();
+            for (const classroom of accessibleClassrooms) {
+              summaryMap.set(classroom.id, {
+                classroomId: classroom.id,
+                classroomName: classroom.name,
+                counts: { P: 0, A: 0, R: 0 },
+              });
+            }
+
+            for (const row of attendanceRows) {
+              const summary = summaryMap.get(row.classroom_id);
+              if (!summary) continue;
+              if (row.status && summary.counts[row.status] !== undefined) {
+                summary.counts[row.status] += 1;
+              }
+            }
+
+            setAttendanceToday(Array.from(summaryMap.values()));
+          } else {
+            setAttendanceToday([]);
+          }
+
+          const { data: latestRows, error: latestError } = await supabase
+            .from("attendance")
+            .select(
+              "id, date, status, classroom:classroom_id (name), student:student_id (id, school_id, full_name, first_name, last_name)",
+            )
+            .order("date", { ascending: false })
+            .limit(5);
+
+          if (latestError) {
+            if (latestError.code !== "42P01") {
+              throw new Error(formatQueryError("attendance.latest", latestError));
+            }
+          }
+
+          if (ignore) return;
+
+          if (latestRows) {
+            const rows: LatestAttendanceRow[] = latestRows.map((row) => {
+              const classroomName = (row.classroom as { name: string } | null)?.name ?? "Sin salón";
+              const studentRecord = row.student as
+                | {
+                    id: string;
+                    school_id: string;
+                    full_name: string | null;
+                    first_name: string;
+                    last_name: string;
+                  }
+                | null;
+              const studentName = studentRecord
+                ? getStudentDisplayName({
+                    id: studentRecord.id,
+                    school_id: studentRecord.school_id,
+                    first_name: studentRecord.first_name,
+                    last_name: studentRecord.last_name,
+                    full_name: studentRecord.full_name,
+                    date_of_birth: null,
+                  })
+                : "Sin alumno";
+              return {
+                id: row.id,
+                date: row.date,
+                status: (row.status as AttendanceStatus) ?? null,
+                classroomName,
+                studentName,
+              };
+            });
+            setLatestAttendance(rows);
+          } else {
+            setLatestAttendance([]);
+          }
+        } else {
+          setAttendanceToday([]);
+          setLatestAttendance([]);
+        }
+      } catch (err) {
+        if (ignore) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+      } finally {
+        if (!ignore) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadDashboard();
+
+    return () => {
+      ignore = true;
+    };
+  }, [router, supabase, typedSupabase]);
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+    router.replace("/login");
+  };
 
   return (
     <main className="flex flex-1 flex-col gap-6">
       <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
         <h1 className="text-2xl font-semibold">Panel</h1>
-        <p className="mt-2 text-sm text-slate-500">
-          Bienvenido{profile?.display_name ? `, ${profile.display_name}` : ""}. Tu rol es <strong>{profile?.role}</strong>
-          {profile?.school?.name ? ` en ${profile.school.name}` : ""}.
-        </p>
+        {profileDetails ? (
+          <p className="mt-2 text-sm text-slate-500">
+            Bienvenido
+            {profileDetails.display_name ? `, ${profileDetails.display_name}` : ""}. Tu rol es
+            <strong> {role ?? "desconocido"}</strong>
+            {profileDetails.school?.name ? ` en ${profileDetails.school.name}` : ""}.
+          </p>
+        ) : (
+          <p className="mt-2 text-sm text-slate-500">
+            Cargando información de tu perfil...
+          </p>
+        )}
         <div className="mt-4 flex flex-wrap items-center gap-4">
           <Link href="/role" className="text-sm font-medium text-indigo-600 hover:underline">
             Ver detalle por rol
           </Link>
-          <form action={signOut}>
-            <button type="submit" className="text-sm font-medium text-rose-600 hover:underline">
-              Cerrar sesión
-            </button>
-          </form>
+          <Link href="/attendance" className="text-sm font-medium text-emerald-600 hover:underline">
+            Ir a asistencia
+          </Link>
+          <button type="button" onClick={handleSignOut} className="text-sm font-medium text-rose-600 hover:underline">
+            Cerrar sesión
+          </button>
         </div>
       </section>
 
-      <section className="grid gap-6 md:grid-cols-2">
-        <article className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-semibold">Salones accesibles</h2>
-          <p className="mt-2 text-sm text-slate-500">
-            Listado según tus permisos en Supabase.
-          </p>
-          <ul className="mt-4 space-y-2">
-            {classrooms?.length ? (
-              classrooms.map((classroom) => (
-                <li key={classroom.id} className="rounded border border-slate-100 px-3 py-2">
-                  {classroom.name}
-                </li>
-              ))
+      {error ? (
+        <section className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</section>
+      ) : null}
+
+      {loading ? (
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <p className="text-sm text-slate-500">Cargando datos...</p>
+        </section>
+      ) : (
+        <section className="grid gap-6 md:grid-cols-2">
+          <article className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-xl font-semibold">Resumen general</h2>
+            <p className="mt-2 text-sm text-slate-500">Conteos sujetos a las políticas RLS de tu rol.</p>
+            <ul className="mt-4 space-y-2 text-sm text-slate-600">
+              <li>Total de alumnos accesibles: {totalStudents}</li>
+              <li>Total de salones accesibles: {classrooms.length}</li>
+            </ul>
+          </article>
+
+          <article className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-xl font-semibold">Asistencia de hoy</h2>
+            <p className="mt-2 text-sm text-slate-500">
+              Conteo de estados por salón para la fecha actual.
+            </p>
+            {attendanceToday.length > 0 ? (
+              <ul className="mt-4 space-y-3 text-sm text-slate-700">
+                {attendanceToday.map((summary) => (
+                  <li key={summary.classroomId} className="rounded border border-slate-100 px-3 py-2">
+                    <div className="font-semibold text-slate-800">{summary.classroomName}</div>
+                    <div className="mt-1 flex gap-3 text-xs text-slate-500">
+                      <span>P: {summary.counts.P}</span>
+                      <span>A: {summary.counts.A}</span>
+                      <span>R: {summary.counts.R}</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
             ) : (
-              <li className="text-sm text-slate-400">Sin salones disponibles</li>
+              <p className="mt-4 text-sm text-slate-500">Sin registros de asistencia hoy.</p>
             )}
-          </ul>
-        </article>
-        <article className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-semibold">Alumnos</h2>
-          <p className="mt-2 text-sm text-slate-500">
-            Visualización limitada por las políticas RLS configuradas.
-          </p>
-          <ul className="mt-4 space-y-2">
-            {students?.length ? (
-              students.map((student) => (
-                <li key={student.id} className="rounded border border-slate-100 px-3 py-2">
-                  {student.first_name} {student.last_name}
+          </article>
+        </section>
+      )}
+
+      {!loading ? (
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-xl font-semibold">Últimas asistencias capturadas</h2>
+          <p className="mt-2 text-sm text-slate-500">Muestra los últimos 5 registros según tu rol.</p>
+          {latestAttendance.length > 0 ? (
+            <ul className="mt-4 space-y-2 text-sm text-slate-700">
+              {latestAttendance.map((row) => (
+                <li key={row.id} className="rounded border border-slate-100 px-3 py-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="font-medium text-slate-800">{row.studentName}</span>
+                    <span className="text-xs text-slate-500">{row.date}</span>
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                    <span>Salón: {row.classroomName}</span>
+                    <span>Estado: {row.status ?? "Sin estado"}</span>
+                  </div>
                 </li>
-              ))
-            ) : (
-              <li className="text-sm text-slate-400">Sin alumnos asignados</li>
-            )}
-          </ul>
-        </article>
-      </section>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-4 text-sm text-slate-500">Sin registros recientes disponibles.</p>
+          )}
+        </section>
+      ) : null}
     </main>
   );
 }

--- a/app/debug/attendance/page.tsx
+++ b/app/debug/attendance/page.tsx
@@ -2,149 +2,34 @@
 
 export const dynamic = "force-dynamic";
 
-import { useEffect, useMemo, useState } from "react";
-import { createClientSupabaseClient } from "@/lib/supabase/client";
+import { useSyncExternalStore } from "react";
 import {
-  fetchAccessibleClassrooms,
-  type AttendanceClassroom,
-  type AttendanceRole,
-  type TypedSupabaseClient,
-} from "@/lib/attendance/client";
-import type { Database } from "@/types/database";
-
-type ProfileInfo = Pick<
-  Database["public"]["Tables"]["user_profile"]["Row"],
-  "role" | "school_id"
->;
-
-type DebugAttendanceRow = Pick<
-  Database["public"]["Tables"]["attendance"]["Row"],
-  "id" | "student_id" | "classroom_id" | "date" | "status" | "taken_by"
->;
-
-type DebugState = {
-  loading: boolean;
-  userId: string | null;
-  role: AttendanceRole | null;
-  classroomsDisponibles: AttendanceClassroom[];
-  sampleQuery: unknown;
-  error: string | null;
-};
-
-const initialState: DebugState = {
-  loading: true,
-  userId: null,
-  role: null,
-  classroomsDisponibles: [],
-  sampleQuery: null,
-  error: null,
-};
+  getAttendanceDebugState,
+  subscribeAttendanceDebugState,
+} from "@/lib/attendance/debug-store";
 
 export default function DebugAttendancePage() {
-  const supabase = useMemo(() => createClientSupabaseClient(), []);
-  const typedSupabase = supabase as unknown as TypedSupabaseClient;
-  const [state, setState] = useState<DebugState>(initialState);
+  const debugState = useSyncExternalStore(subscribeAttendanceDebugState, getAttendanceDebugState);
 
-  useEffect(() => {
-    let ignore = false;
-    async function loadDebug() {
-      try {
-        setState(initialState);
-        const {
-          data: { user },
-          error: userError,
-        } = await supabase.auth.getUser();
-        if (userError) {
-          throw userError;
-        }
-        if (ignore) return;
-        const userId = user?.id ?? null;
-        let role: AttendanceRole | null = null;
-        let schoolId: string | null = null;
-        let errorMessage: string | null = null;
-
-        if (userId) {
-          const { data: profile, error: profileError } = await supabase
-            .from("user_profile")
-            .select("role, school_id")
-            .eq("id", userId)
-            .maybeSingle<ProfileInfo>();
-          if (profileError) {
-            errorMessage = profileError.message;
-          } else {
-            role = profile?.role ?? null;
-            schoolId = profile?.school_id ?? null;
-          }
-        }
-
-        let classrooms: AttendanceClassroom[] = [];
-        if (userId && role) {
-          try {
-            classrooms = await fetchAccessibleClassrooms(typedSupabase, role, userId, schoolId);
-          } catch (classroomError) {
-            errorMessage = classroomError instanceof Error ? classroomError.message : String(classroomError);
-          }
-        }
-
-        const { data: sampleData, error: sampleError } = await supabase
-          .from("attendance")
-          .select("id, student_id, classroom_id, date, status, taken_by")
-          .limit(5)
-          .returns<DebugAttendanceRow[]>();
-        if (sampleError && !errorMessage) {
-          errorMessage = sampleError.message;
-        }
-
-        if (ignore) return;
-        setState({
-          loading: false,
-          userId,
-          role,
-          classroomsDisponibles: classrooms,
-          sampleQuery: sampleData ?? null,
-          error: errorMessage,
-        });
-      } catch (err) {
-        if (ignore) return;
-        const message = err instanceof Error ? err.message : String(err);
-        setState({
-          loading: false,
-          userId: null,
-          role: null,
-          classroomsDisponibles: [],
-          sampleQuery: null,
-          error: message,
-        });
-      }
-    }
-    loadDebug();
-    return () => {
-      ignore = true;
-    };
-  }, [supabase]);
+  const payload = {
+    user: debugState.user,
+    role: debugState.role,
+    classrooms: debugState.classrooms,
+    studentsCountSelected: debugState.studentsCountSelected,
+    lastError: debugState.lastError,
+  };
 
   return (
     <main className="flex flex-1 flex-col gap-6">
       <header>
         <h1 className="text-2xl font-semibold text-slate-900">Debug asistencia</h1>
         <p className="text-sm text-slate-600">
-          Información útil para revisar el alcance de las políticas RLS en la tabla de asistencia.
+          Estado compartido desde la pantalla de asistencia para validar datos de Supabase y RLS.
         </p>
       </header>
       <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-        <pre className="whitespace-pre-wrap text-sm text-slate-700">
-          {JSON.stringify(
-            {
-              userId: state.userId,
-              role: state.role,
-              classroomsDisponibles: state.classroomsDisponibles,
-              sampleQuery: state.sampleQuery,
-              error: state.error,
-              loading: state.loading,
-            },
-            null,
-            2,
-          )}
+        <pre className="whitespace-pre-wrap break-words text-sm text-slate-700">
+          {JSON.stringify(payload, null, 2)}
         </pre>
       </section>
     </main>

--- a/app/debug/attendance/page.tsx
+++ b/app/debug/attendance/page.tsx
@@ -4,12 +4,17 @@ export const dynamic = "force-dynamic";
 
 import { useSyncExternalStore } from "react";
 import {
+  getAttendanceDebugServerState,
   getAttendanceDebugState,
   subscribeAttendanceDebugState,
 } from "@/lib/attendance/debug-store";
 
 export default function DebugAttendancePage() {
-  const debugState = useSyncExternalStore(subscribeAttendanceDebugState, getAttendanceDebugState);
+  const debugState = useSyncExternalStore(
+    subscribeAttendanceDebugState,
+    getAttendanceDebugState,
+    getAttendanceDebugServerState,
+  );
 
   const payload = {
     user: debugState.user,

--- a/lib/attendance/client.ts
+++ b/lib/attendance/client.ts
@@ -8,75 +8,170 @@ export type AttendanceClassroom = {
   name: string;
 };
 
+export type AttendanceProfile = Pick<
+  Database["public"]["Tables"]["user_profile"]["Row"],
+  "id" | "role" | "school_id"
+>;
+
+export type AttendanceStudentRow = Pick<
+  Database["public"]["Tables"]["student"]["Row"],
+  "id" | "school_id" | "first_name" | "last_name" | "full_name" | "date_of_birth"
+>;
+
 export type TypedSupabaseClient = SupabaseClient<Database>;
 
-export async function fetchAccessibleClassrooms(
+export async function getMyProfile(
+  supabase: TypedSupabaseClient,
+  userId: string,
+): Promise<AttendanceProfile | null> {
+  const { data, error } = await supabase
+    .from("user_profile")
+    .select("id, role, school_id")
+    .eq("id", userId)
+    .maybeSingle<AttendanceProfile>();
+
+  if (error) {
+    throw error;
+  }
+
+  return data ?? null;
+}
+
+export async function getClassroomsForUser(
   supabase: TypedSupabaseClient,
   role: AttendanceRole | null,
-  userId: string,
-  schoolId: string | null
+  profile: AttendanceProfile | null,
 ): Promise<AttendanceClassroom[]> {
-  if (!role) {
+  if (!role || !profile) {
     return [];
   }
 
   if (role === "director") {
-    if (!schoolId) {
+    if (!profile.school_id) {
       return [];
     }
     const { data, error } = await supabase
       .from("classroom")
       .select("id, name")
-      .eq("school_id", schoolId)
+      .eq("school_id", profile.school_id)
       .order("name", { ascending: true });
+
     if (error) {
       throw error;
     }
+
     return data ?? [];
   }
 
   if (role === "teacher") {
-    const { data, error } = await supabase
+    const { data: assignments, error: assignmentsError } = await supabase
       .from("teacher_classroom")
-      .select("classroom:classroom_id (id, name)")
-      .eq("teacher_id", userId);
+      .select("classroom_id")
+      .eq("teacher_id", profile.id);
+
+    if (assignmentsError) {
+      throw assignmentsError;
+    }
+
+    const classroomIds = (assignments ?? [])
+      .map((assignment) => assignment.classroom_id)
+      .filter((value): value is string => Boolean(value));
+
+    if (classroomIds.length === 0) {
+      return [];
+    }
+
+    const { data, error } = await supabase
+      .from("classroom")
+      .select("id, name")
+      .in("id", classroomIds)
+      .order("name", { ascending: true });
+
     if (error) {
       throw error;
     }
-    const map = new Map<string, AttendanceClassroom>();
-    for (const item of data ?? []) {
-      const classroom = item.classroom as { id: string; name: string } | null;
-      if (classroom) {
-        map.set(classroom.id, classroom);
-      }
-    }
-    return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+
+    return data ?? [];
   }
 
-  // Guardian role
-  const { data, error } = await supabase
-    .from("guardian")
-    .select("student:student_id (enrollments:enrollment (classroom:classroom_id (id, name)))")
-    .eq("profile_id", userId);
-  if (error) {
-    throw error;
-  }
-  const map = new Map<string, AttendanceClassroom>();
-  for (const guardian of data ?? []) {
-    const student = guardian.student as
-      | {
-          enrollments: { classroom: { id: string; name: string } | null }[] | null;
-        }
-      | null;
-    if (!student?.enrollments) {
-      continue;
+  if (role === "parent") {
+    const { data, error } = await supabase
+      .from("guardian")
+      .select("student:student_id (enrollments:enrollment (classroom_id))")
+      .eq("profile_id", profile.id);
+
+    if (error) {
+      throw error;
     }
-    for (const enrollment of student.enrollments) {
-      const classroom = enrollment.classroom;
-      if (classroom) {
-        map.set(classroom.id, classroom);
+
+    const classroomIds = new Set<string>();
+    for (const row of data ?? []) {
+      const student = row.student as { enrollments: { classroom_id: string | null }[] | null } | null;
+      if (!student?.enrollments) continue;
+      for (const enrollment of student.enrollments) {
+        if (enrollment.classroom_id) {
+          classroomIds.add(enrollment.classroom_id);
+        }
       }
     }
+
+    if (classroomIds.size === 0) {
+      return [];
+    }
+
+    const { data: classrooms, error: classroomsError } = await supabase
+      .from("classroom")
+      .select("id, name")
+      .in("id", Array.from(classroomIds))
+      .order("name", { ascending: true });
+
+    if (classroomsError) {
+      throw classroomsError;
+    }
+
+    return classrooms ?? [];
   }
-  return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+
+  return [];
+}
+
+export async function getStudentsForClassroom(
+  supabase: TypedSupabaseClient,
+  classroomId: string,
+): Promise<AttendanceStudentRow[]> {
+  const { data: enrollmentRows, error: enrollmentError } = await supabase
+    .from("enrollment")
+    .select("student_id")
+    .eq("classroom_id", classroomId);
+
+  if (enrollmentError) {
+    throw enrollmentError;
+  }
+
+  const studentIds = (enrollmentRows ?? []).map((row) => row.student_id).filter((value): value is string => Boolean(value));
+
+  if (studentIds.length === 0) {
+    return [];
+  }
+
+  const { data: students, error: studentsError } = await supabase
+    .from("student")
+    .select("id, school_id, first_name, last_name, full_name, date_of_birth")
+    .in("id", studentIds);
+
+  if (studentsError) {
+    throw studentsError;
+  }
+
+  return students ?? [];
+}
+
+export function getStudentDisplayName(student: AttendanceStudentRow): string {
+  const fromFullName = student.full_name?.trim();
+  if (fromFullName) {
+    return fromFullName;
+  }
+
+  const names = [student.first_name, student.last_name].filter((value) => Boolean(value && value.trim()));
+  return names.join(" ").trim();
 }

--- a/lib/attendance/debug-store.ts
+++ b/lib/attendance/debug-store.ts
@@ -1,0 +1,53 @@
+import type { AttendanceClassroom, AttendanceRole } from "./client";
+
+type AttendanceDebugUser = {
+  id: string | null;
+  email: string | null;
+};
+
+type AttendanceDebugState = {
+  user: AttendanceDebugUser;
+  role: AttendanceRole | null;
+  classrooms: AttendanceClassroom[];
+  studentsCountSelected: number;
+  lastError: string | null;
+};
+
+const defaultState: AttendanceDebugState = {
+  user: { id: null, email: null },
+  role: null,
+  classrooms: [],
+  studentsCountSelected: 0,
+  lastError: null,
+};
+
+let state: AttendanceDebugState = defaultState;
+const listeners = new Set<() => void>();
+
+export function getAttendanceDebugState(): AttendanceDebugState {
+  return state;
+}
+
+export function subscribeAttendanceDebugState(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function updateAttendanceDebugState(partial: Partial<AttendanceDebugState>): void {
+  state = {
+    ...state,
+    ...partial,
+  };
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function resetAttendanceDebugState(): void {
+  state = defaultState;
+  for (const listener of listeners) {
+    listener();
+  }
+}

--- a/lib/attendance/debug-store.ts
+++ b/lib/attendance/debug-store.ts
@@ -28,6 +28,10 @@ export function getAttendanceDebugState(): AttendanceDebugState {
   return state;
 }
 
+export function getAttendanceDebugServerState(): AttendanceDebugState {
+  return defaultState;
+}
+
 export function subscribeAttendanceDebugState(listener: () => void): () => void {
   listeners.add(listener);
   return () => {

--- a/types/database.ts
+++ b/types/database.ts
@@ -204,6 +204,7 @@ export interface Database {
           created_at: string | null;
           date_of_birth: string | null;
           first_name: string;
+          full_name: string | null;
           id: string;
           last_name: string;
           school_id: string;
@@ -212,6 +213,7 @@ export interface Database {
           created_at?: string | null;
           date_of_birth?: string | null;
           first_name: string;
+          full_name?: string | null;
           id?: string;
           last_name: string;
           school_id: string;
@@ -220,6 +222,7 @@ export interface Database {
           created_at?: string | null;
           date_of_birth?: string | null;
           first_name?: string;
+          full_name?: string | null;
           id?: string;
           last_name?: string;
           school_id?: string;


### PR DESCRIPTION
## Summary
- refactor attendance page to load profile, classrooms and students from Supabase using client-side helpers and show real error messages
- add a shared debug store and update the debug route to expose user, role, classroom and error information
- refresh the dashboard to run on the client, show attendance summaries/counts and link to the attendance view; document data requirements and add ESLint config

## Testing
- npx eslint . --max-warnings=0

## Vercel preview
1. Deploy this branch to a Vercel preview environment.
2. Visit `<preview-url>/attendance` as director and teacher users; verify classrooms and students load and any errors show Supabase messages.
3. Visit `<preview-url>/dashboard` to review the totals, daily attendance summary and latest records.
4. Visit `<preview-url>/debug/attendance` after using the attendance page to confirm the JSON debug payload updates.


------
https://chatgpt.com/codex/tasks/task_e_68cf1dc720288333a9951a6637e589a7