### PR TITLE
Fix dashboard profile handling and add debug page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/README.md
+++ b/README.md
@@ -74,4 +74,19 @@ Bootstrap inicial de la plataforma escolar preescolar construida con Next.js, Ta
 
 ## Nota sobre autenticación
 
-La pantalla de `/login` utiliza el componente oficial de Supabase Auth UI. Al iniciar sesión, la sesión se almacena en cookies manejadas por `@supabase/auth-helpers-nextjs`. Los componentes del dashboard y del detalle de rol verifican la sesión en el servidor y aplican redirecciones a `/login` en caso de no existir.
+La pantalla de `/login` utiliza el componente oficial de Supabase Auth UI. Al iniciar sesión, la sesión se almacena en cookies manejadas por `@supabase/auth-helpers-nextjs`. Las páginas de `/dashboard`, `/role` y `/debug/profile` leen la sesión con el cliente de Supabase del lado del navegador y redirigen a `/login` si no existe una sesión válida.
+
+## Si ves "getMyProfile" en rojo
+
+1. Verifica que las variables `NEXT_PUBLIC_SUPABASE_URL` y `NEXT_PUBLIC_SUPABASE_ANON_KEY` estén configuradas en tu entorno (por ejemplo, en Vercel → Project Settings → Environment Variables) y que coincidan con tu proyecto de Supabase.
+2. Asegúrate de que exista una fila en la tabla `user_profile` con `id` igual a tu `auth.uid` (el UUID del usuario autenticado), `school_id` y `role` definidos. Puedes crearla desde Supabase → Table editor.
+3. Confirma que la política RLS permita leer tu propio perfil. Un ejemplo mínimo es:
+
+   ```sql
+   alter table public.user_profile enable row level security;
+   drop policy if exists up_self on public.user_profile;
+   create policy up_self on public.user_profile
+   for select using (id = auth.uid());
+   ```
+
+4. Con la sesión iniciada, visita `/debug/profile` para obtener un JSON de diagnóstico que confirma tu usuario, los valores encontrados en `user_profile` y si las variables de entorno públicas están disponibles.

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,110 +1,209 @@
+"use client";
+
 import Link from "next/link";
-import { redirect } from "next/navigation";
-import { createServerSupabaseClient } from "@/lib/supabase/server";
-import type { Database } from "@/types/database";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-export const dynamic = "force-dynamic";
+import { toMessage } from "@/lib/errors";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
 
-type DashboardProfile = Pick<
-  Database["public"]["Tables"]["user_profile"]["Row"],
-  "id" | "display_name" | "role"
-> & {
-  school: { name: string } | null;
+type Profile = {
+  role: string | null;
+  full_name: string | null;
+  school_id: string | null;
 };
 
-type DashboardClassroom = Pick<Database["public"]["Tables"]["classroom"]["Row"], "id" | "name">;
+type CountResult = {
+  count: number | null;
+  errorMessage: string | null;
+};
 
-type DashboardStudent = Pick<Database["public"]["Tables"]["student"]["Row"], "id" | "first_name" | "last_name">;
+const zeroTooltip =
+  "Si ves 0, revisa: variables NEXT_PUBLIC_SUPABASE_URL/ANON_KEY, tu fila en user_profile y las políticas RLS.";
 
-export default async function DashboardPage() {
-  const supabase = createServerSupabaseClient();
-  const {
-    data: { session }
-  } = await supabase.auth.getSession();
+export default function DashboardPage() {
+  const router = useRouter();
+  const supabase = useMemo(() => createClientSupabaseClient(), []);
+  const [loading, setLoading] = useState(true);
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [profileError, setProfileError] = useState<string | null>(null);
+  const [studentsState, setStudentsState] = useState<CountResult>({
+    count: null,
+    errorMessage: null
+  });
+  const [classroomsState, setClassroomsState] = useState<CountResult>({
+    count: null,
+    errorMessage: null
+  });
 
-  if (!session) {
-    redirect("/login");
-  }
+  const [userEmail, setUserEmail] = useState<string | null>(null);
 
-  async function signOut() {
-    "use server";
-    const serverClient = createServerSupabaseClient();
-    await serverClient.auth.signOut();
-    redirect("/login");
-  }
+  useEffect(() => {
+    let active = true;
 
-  const { data: profile } = await supabase
-    .from("user_profile")
-    .select("id, display_name, role, school(name)")
-    .eq("id", session.user.id)
-    .maybeSingle<DashboardProfile>();
+    async function load() {
+      setLoading(true);
+      setProfileError(null);
+      try {
+        const {
+          data: { user },
+          error: userError
+        } = await supabase.auth.getUser();
 
-  const { data: classrooms } = await supabase
-    .from("classroom")
-    .select("id, name")
-    .order("name", { ascending: true })
-    .returns<DashboardClassroom[]>();
+        if (!active) {
+          return;
+        }
 
-  const { data: students } = await supabase
-    .from("student")
-    .select("id, first_name, last_name")
-    .order("first_name", { ascending: true })
-    .returns<DashboardStudent[]>();
+        if (userError) {
+          setProfileError(toMessage(userError));
+          return;
+        }
+
+        if (!user) {
+          router.replace("/login");
+          return;
+        }
+
+        setUserEmail(user.email ?? null);
+
+        const [{ data: profileData, error: profileError }, classrooms, students] = await Promise.all([
+          supabase
+            .from("user_profile")
+            .select("role, full_name, school_id")
+            .eq("id", user.id)
+            .maybeSingle<Profile>(),
+          supabase
+            .from("classroom")
+            .select("id", { count: "exact", head: true }),
+          supabase
+            .from("student")
+            .select("id", { count: "exact", head: true })
+        ]);
+
+        if (!active) {
+          return;
+        }
+
+        if (profileError) {
+          setProfileError(toMessage(profileError));
+        }
+
+        setProfile(profileData ?? null);
+
+        setClassroomsState({
+          count: typeof classrooms.count === "number" ? classrooms.count : null,
+          errorMessage: classrooms.error ? toMessage(classrooms.error) : null
+        });
+
+        setStudentsState({
+          count: typeof students.count === "number" ? students.count : null,
+          errorMessage: students.error ? toMessage(students.error) : null
+        });
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+        setProfileError(toMessage(error));
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, [router, supabase]);
+
+  const handleSignOut = useCallback(async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      setProfileError(toMessage(error));
+      return;
+    }
+    router.replace("/login");
+  }, [router, supabase]);
+
+  const fullName = profile?.full_name ?? undefined;
+  const role = profile?.role ?? undefined;
 
   return (
     <main className="flex flex-1 flex-col gap-6">
       <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
         <h1 className="text-2xl font-semibold">Panel</h1>
+        {profileError ? (
+          <p className="mt-3 rounded border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+            getMyProfile: {profileError}
+          </p>
+        ) : null}
         <p className="mt-2 text-sm text-slate-500">
-          Bienvenido{profile?.display_name ? `, ${profile.display_name}` : ""}. Tu rol es <strong>{profile?.role}</strong>
-          {profile?.school?.name ? ` en ${profile.school.name}` : ""}.
+          {loading ? (
+            "Cargando tu información..."
+          ) : (
+            <>
+              Bienvenido
+              {fullName ? `, ${fullName}` : userEmail ? `, ${userEmail}` : ""}. Tu rol es {" "}
+              {role ? <strong>{role}</strong> : <span className="font-semibold text-amber-600">(sin rol)</span>}.
+            </>
+          )}
         </p>
         <div className="mt-4 flex flex-wrap items-center gap-4">
           <Link href="/role" className="text-sm font-medium text-indigo-600 hover:underline">
             Ver detalle por rol
           </Link>
-          <form action={signOut}>
-            <button type="submit" className="text-sm font-medium text-rose-600 hover:underline">
-              Cerrar sesión
-            </button>
-          </form>
+          <button
+            type="button"
+            onClick={handleSignOut}
+            className="text-sm font-medium text-rose-600 hover:underline"
+          >
+            Cerrar sesión
+          </button>
         </div>
+        {!profile && !loading ? (
+          <div className="mt-4 rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+            No se encontró tu user_profile. Ve a Supabase → Table editor → user_profile e inserta una fila con id =
+            tu auth.uid, school_id y role.
+          </div>
+        ) : null}
       </section>
 
       <section className="grid gap-6 md:grid-cols-2">
         <article className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-semibold">Salones accesibles</h2>
-          <p className="mt-2 text-sm text-slate-500">
-            Listado según tus permisos en Supabase.
-          </p>
-          <ul className="mt-4 space-y-2">
-            {classrooms?.length ? (
-              classrooms.map((classroom) => (
-                <li key={classroom.id} className="rounded border border-slate-100 px-3 py-2">
-                  {classroom.name}
-                </li>
-              ))
-            ) : (
-              <li className="text-sm text-slate-400">Sin salones disponibles</li>
-            )}
-          </ul>
+          <h2 className="text-xl font-semibold">Salones visibles</h2>
+          <p className="mt-1 text-sm text-slate-500">Conteo según tus permisos actuales.</p>
+          <div
+            className="mt-6 text-4xl font-semibold text-slate-900"
+            title={classroomsState.count === 0 ? zeroTooltip : undefined}
+          >
+            {typeof classroomsState.count === "number" ? classroomsState.count : "–"}
+          </div>
+          {classroomsState.errorMessage ? (
+            <p className="mt-3 text-sm text-rose-600">{classroomsState.errorMessage}</p>
+          ) : classroomsState.count === 0 ? (
+            <p className="mt-3 text-xs text-slate-500">
+              Tip: revisa variables de entorno, tu user_profile y que las políticas RLS permitan leer los salones.
+            </p>
+          ) : null}
         </article>
         <article className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-semibold">Alumnos</h2>
-          <p className="mt-2 text-sm text-slate-500">
-            Visualización limitada por las políticas RLS configuradas.
-          </p>
-          <ul className="mt-4 space-y-2">
-            {students?.length ? (
-              students.map((student) => (
-                <li key={student.id} className="rounded border border-slate-100 px-3 py-2">
-                  {student.first_name} {student.last_name}
-                </li>
-              ))
-            ) : (
-              <li className="text-sm text-slate-400">Sin alumnos asignados</li>
-            )}
-          </ul>
+          <h2 className="text-xl font-semibold">Alumnos visibles</h2>
+          <p className="mt-1 text-sm text-slate-500">Número limitado por tus políticas RLS.</p>
+          <div
+            className="mt-6 text-4xl font-semibold text-slate-900"
+            title={studentsState.count === 0 ? zeroTooltip : undefined}
+          >
+            {typeof studentsState.count === "number" ? studentsState.count : "–"}
+          </div>
+          {studentsState.errorMessage ? (
+            <p className="mt-3 text-sm text-rose-600">{studentsState.errorMessage}</p>
+          ) : studentsState.count === 0 ? (
+            <p className="mt-3 text-xs text-slate-500">
+              Tip: verifica tus variables de entorno, que exista tu user_profile y las políticas RLS de student.
+            </p>
+          ) : null}
         </article>
       </section>
     </main>

--- a/app/debug/profile/page.tsx
+++ b/app/debug/profile/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import { toMessage } from "@/lib/errors";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
+
+type Profile = {
+  role: string | null;
+  school_id: string | null;
+  full_name: string | null;
+};
+
+export default function DebugProfilePage() {
+  const router = useRouter();
+  const supabase = useMemo(() => createClientSupabaseClient(), []);
+  const [payload, setPayload] = useState({
+    userId: null as string | null,
+    email: null as string | null,
+    profile: null as Profile | null,
+    errorMessage: null as string | null,
+    loading: true
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        const {
+          data: { user },
+          error
+        } = await supabase.auth.getUser();
+
+        if (!active) {
+          return;
+        }
+
+        if (error) {
+          setPayload((prev) => ({ ...prev, loading: false, errorMessage: toMessage(error) }));
+          return;
+        }
+
+        if (!user) {
+          router.replace("/login");
+          return;
+        }
+
+        const { data, error: profileError } = await supabase
+          .from("user_profile")
+          .select("role, school_id, full_name")
+          .eq("id", user.id)
+          .maybeSingle<Profile>();
+
+        if (!active) {
+          return;
+        }
+
+        setPayload({
+          userId: user.id,
+          email: user.email ?? null,
+          profile: data ?? null,
+          errorMessage: profileError ? toMessage(profileError) : null,
+          loading: false
+        });
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+        setPayload((prev) => ({
+          ...prev,
+          loading: false,
+          errorMessage: toMessage(error)
+        }));
+      }
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, [router, supabase]);
+
+  const env = {
+    hasURL: Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL),
+    hasAnon: Boolean(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
+  };
+
+  const body = {
+    userId: payload.userId,
+    email: payload.email,
+    profile: payload.profile,
+    errorMessage: payload.errorMessage,
+    env,
+    loading: payload.loading
+  };
+
+  return (
+    <main className="flex flex-1 flex-col gap-4">
+      <pre className="overflow-auto rounded border border-slate-200 bg-slate-950 p-4 text-xs text-slate-100">
+        {JSON.stringify(body, null, 2)}
+      </pre>
+    </main>
+  );
+}

--- a/app/role/page.tsx
+++ b/app/role/page.tsx
@@ -1,10 +1,24 @@
-import { redirect } from "next/navigation";
-import { createServerSupabaseClient } from "@/lib/supabase/server";
-import type { Database } from "@/types/database";
+"use client";
 
-export const dynamic = "force-dynamic";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 
-const roleDescriptions: Record<string, { title: string; description: string; focus: string[] }> = {
+import { toMessage } from "@/lib/errors";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
+
+type RoleProfile = {
+  role: string | null;
+  full_name: string | null;
+  school_id: string | null;
+};
+
+type RoleDescriptor = {
+  title: string;
+  description: string;
+  focus: string[];
+};
+
+const roleDescriptions: Record<string, RoleDescriptor> = {
   director: {
     title: "Directora / Director",
     description:
@@ -15,6 +29,16 @@ const roleDescriptions: Record<string, { title: string; description: string; foc
       "Acompañar a maestras y familias"
     ]
   },
+  maestra: {
+    title: "Maestra",
+    description:
+      "Acceso restringido únicamente a los salones donde ha sido asignada y a los estudiantes inscritos en ellos.",
+    focus: [
+      "Revisar alumnos y tutores de su salón",
+      "Actualizar información diaria del aula",
+      "Comunicar novedades a las familias"
+    ]
+  },
   teacher: {
     title: "Maestra",
     description:
@@ -23,6 +47,26 @@ const roleDescriptions: Record<string, { title: string; description: string; foc
       "Revisar alumnos y tutores de su salón",
       "Actualizar información diaria del aula",
       "Comunicar novedades a las familias"
+    ]
+  },
+  padre: {
+    title: "Padre / Madre / Tutor",
+    description:
+      "Puede consultar exclusivamente los datos de sus hijos registrados en la plataforma.",
+    focus: [
+      "Revisar el progreso académico y comunicados",
+      "Actualizar información de contacto",
+      "Enviar mensajes a la escuela"
+    ]
+  },
+  madre: {
+    title: "Padre / Madre / Tutor",
+    description:
+      "Puede consultar exclusivamente los datos de sus hijos registrados en la plataforma.",
+    focus: [
+      "Revisar el progreso académico y comunicados",
+      "Actualizar información de contacto",
+      "Enviar mensajes a la escuela"
     ]
   },
   parent: {
@@ -37,40 +81,98 @@ const roleDescriptions: Record<string, { title: string; description: string; foc
   }
 };
 
-export default async function RolePage() {
-  const supabase = createServerSupabaseClient();
-  const {
-    data: { session }
-  } = await supabase.auth.getSession();
+export default function RolePage() {
+  const router = useRouter();
+  const supabase = useMemo(() => createClientSupabaseClient(), []);
+  const [profile, setProfile] = useState<RoleProfile | null>(null);
+  const [profileError, setProfileError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
-  if (!session) {
-    redirect("/login");
-  }
+  useEffect(() => {
+    let active = true;
 
-  type RoleProfile = Pick<Database["public"]["Tables"]["user_profile"]["Row"], "role"> & {
-    school: { name: string } | null;
-  };
+    async function load() {
+      setLoading(true);
+      setProfileError(null);
+      try {
+        const {
+          data: { user },
+          error: userError
+        } = await supabase.auth.getUser();
 
-  const { data: profile } = await supabase
-    .from("user_profile")
-    .select("role, school(name)")
-    .eq("id", session.user.id)
-    .maybeSingle<RoleProfile>();
+        if (!active) {
+          return;
+        }
 
-  const descriptor = roleDescriptions[profile?.role ?? ""];
+        if (userError) {
+          setProfileError(toMessage(userError));
+          return;
+        }
+
+        if (!user) {
+          router.replace("/login");
+          return;
+        }
+
+        const { data, error } = await supabase
+          .from("user_profile")
+          .select("role, full_name, school_id")
+          .eq("id", user.id)
+          .maybeSingle<RoleProfile>();
+
+        if (!active) {
+          return;
+        }
+
+        if (error) {
+          setProfileError(toMessage(error));
+        }
+
+        setProfile(data ?? null);
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+        setProfileError(toMessage(error));
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, [router, supabase]);
+
+  const descriptor = profile?.role ? roleDescriptions[profile.role] : undefined;
 
   return (
     <main className="flex flex-1 flex-col gap-6">
       <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
         <h1 className="text-2xl font-semibold">Detalle de rol</h1>
+        {profileError ? (
+          <p className="mt-3 rounded border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+            getMyProfile: {profileError}
+          </p>
+        ) : null}
+        {!profile && !loading ? (
+          <p className="mt-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            No se encontró tu user_profile. Ve a Supabase → Table editor → user_profile e inserta una fila con id = tu auth.uid,
+            school_id y role.
+          </p>
+        ) : null}
+        {profile?.full_name ? (
+          <p className="mt-4 text-sm text-slate-600">Nombre: {profile.full_name}</p>
+        ) : null}
         {descriptor ? (
           <div className="mt-4 space-y-4">
             <div>
               <p className="text-sm uppercase tracking-wide text-slate-500">Tu rol</p>
               <h2 className="text-xl font-semibold">{descriptor.title}</h2>
-              {profile?.school?.name ? (
-                <p className="mt-1 text-sm text-slate-500">Escuela: {profile.school.name}</p>
-              ) : null}
             </div>
             <p className="text-base text-slate-600">{descriptor.description}</p>
             <div>
@@ -82,11 +184,11 @@ export default async function RolePage() {
               </ul>
             </div>
           </div>
-        ) : (
-          <p className="text-sm text-slate-500">
+        ) : !loading ? (
+          <p className="mt-4 text-sm text-slate-500">
             Aún no se ha configurado tu rol. Solicita asistencia a la dirección.
           </p>
-        )}
+        ) : null}
       </section>
     </main>
   );

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,24 @@
+export function toMessage(error: unknown): string {
+  if (!error) {
+    return "Error desconocido";
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (typeof error === "object") {
+    const maybeMessage = (error as { message?: unknown }).message;
+    if (typeof maybeMessage === "string" && maybeMessage.trim().length > 0) {
+      return maybeMessage;
+    }
+
+    try {
+      return JSON.stringify(error);
+    } catch (serializationError) {
+      return `Error inesperado: ${serializationError}`;
+    }
+  }
+
+  return String(error);
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,5 +1,12 @@
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+
 import type { Database } from "@/types/database";
 
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
 export const createClientSupabaseClient = () =>
-  createClientComponentClient<Database>();
+  createClientComponentClient<Database>({
+    ...(supabaseUrl ? { supabaseUrl } : {}),
+    ...(supabaseAnonKey ? { supabaseKey: supabaseAnonKey } : {})
+  });


### PR DESCRIPTION
## Summary
- normalize error handling with a new `toMessage` helper and ensure the Supabase client uses public env vars
- refactor `/dashboard` and `/role` into client components that fetch the authenticated profile safely and surface actionable messages
- add `/debug/profile` diagnostics, configure ESLint, and document recovery steps for the getMyProfile banner

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf2acade608333b2c83008251e03da