### PR TITLE
Improve dashboard error handling and add debug endpoints

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -16,6 +16,19 @@ type DashboardClassroom = Pick<Database["public"]["Tables"]["classroom"]["Row"],
 
 type DashboardStudent = Pick<Database["public"]["Tables"]["student"]["Row"], "id" | "first_name" | "last_name">;
 
+type QueryError = {
+  message?: string | null;
+  details?: string | null;
+  hint?: string | null;
+} | null;
+
+function getErrorMessage(error: QueryError) {
+  if (!error) {
+    return null;
+  }
+  return error.message || error.details || error.hint || "(sin mensaje)";
+}
+
 export default async function DashboardPage() {
   const supabase = createServerSupabaseClient();
   const {
@@ -33,23 +46,39 @@ export default async function DashboardPage() {
     redirect("/login");
   }
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from("user_profile")
     .select("id, display_name, role, school(name)")
     .eq("id", session.user.id)
     .maybeSingle<DashboardProfile>();
 
-  const { data: classrooms } = await supabase
+  if (profileError) {
+    console.error(profileError);
+  }
+
+  const { data: classrooms, error: classroomsError } = await supabase
     .from("classroom")
     .select("id, name")
     .order("name", { ascending: true })
     .returns<DashboardClassroom[]>();
 
-  const { data: students } = await supabase
+  if (classroomsError) {
+    console.error(classroomsError);
+  }
+
+  const { data: students, error: studentsError } = await supabase
     .from("student")
     .select("id, first_name, last_name")
     .order("first_name", { ascending: true })
     .returns<DashboardStudent[]>();
+
+  if (studentsError) {
+    console.error(studentsError);
+  }
+
+  const profileErrorMessage = getErrorMessage(profileError);
+  const classroomsErrorMessage = getErrorMessage(classroomsError);
+  const studentsErrorMessage = getErrorMessage(studentsError);
 
   return (
     <main className="flex flex-1 flex-col gap-6">
@@ -59,6 +88,11 @@ export default async function DashboardPage() {
           Bienvenido{profile?.display_name ? `, ${profile.display_name}` : ""}. Tu rol es <strong>{profile?.role}</strong>
           {profile?.school?.name ? ` en ${profile.school.name}` : ""}.
         </p>
+        {profileErrorMessage ? (
+          <p className="mt-2 text-sm text-rose-600">
+            Error al cargar tu perfil: {profileErrorMessage}
+          </p>
+        ) : null}
         <div className="mt-4 flex flex-wrap items-center gap-4">
           <Link href="/role" className="text-sm font-medium text-indigo-600 hover:underline">
             Ver detalle por rol
@@ -77,34 +111,42 @@ export default async function DashboardPage() {
           <p className="mt-2 text-sm text-slate-500">
             Listado según tus permisos en Supabase.
           </p>
-          <ul className="mt-4 space-y-2">
-            {classrooms?.length ? (
-              classrooms.map((classroom) => (
-                <li key={classroom.id} className="rounded border border-slate-100 px-3 py-2">
-                  {classroom.name}
-                </li>
-              ))
-            ) : (
-              <li className="text-sm text-slate-400">Sin salones disponibles</li>
-            )}
-          </ul>
+          {classroomsErrorMessage ? (
+            <p className="mt-4 text-sm text-rose-600">Error al cargar salones: {classroomsErrorMessage}</p>
+          ) : (
+            <ul className="mt-4 space-y-2">
+              {classrooms?.length ? (
+                classrooms.map((classroom) => (
+                  <li key={classroom.id} className="rounded border border-slate-100 px-3 py-2">
+                    {classroom.name}
+                  </li>
+                ))
+              ) : (
+                <li className="text-sm text-slate-400">Sin salones disponibles</li>
+              )}
+            </ul>
+          )}
         </article>
         <article className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
           <h2 className="text-xl font-semibold">Alumnos</h2>
           <p className="mt-2 text-sm text-slate-500">
             Visualización limitada por las políticas RLS configuradas.
           </p>
-          <ul className="mt-4 space-y-2">
-            {students?.length ? (
-              students.map((student) => (
-                <li key={student.id} className="rounded border border-slate-100 px-3 py-2">
-                  {student.first_name} {student.last_name}
-                </li>
-              ))
-            ) : (
-              <li className="text-sm text-slate-400">Sin alumnos asignados</li>
-            )}
-          </ul>
+          {studentsErrorMessage ? (
+            <p className="mt-4 text-sm text-rose-600">Error al cargar alumnos: {studentsErrorMessage}</p>
+          ) : (
+            <ul className="mt-4 space-y-2">
+              {students?.length ? (
+                students.map((student) => (
+                  <li key={student.id} className="rounded border border-slate-100 px-3 py-2">
+                    {student.first_name} {student.last_name}
+                  </li>
+                ))
+              ) : (
+                <li className="text-sm text-slate-400">Sin alumnos asignados</li>
+              )}
+            </ul>
+          )}
         </article>
       </section>
     </main>

--- a/app/debug/classrooms/route.ts
+++ b/app/debug/classrooms/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import type { Database } from "@/types/database";
+
+export const dynamic = "force-dynamic";
+
+type DashboardClassroom = Pick<Database["public"]["Tables"]["classroom"]["Row"], "id" | "name">;
+
+export async function GET() {
+  const supabase = createServerSupabaseClient();
+  const { data: rows, error } = await supabase
+    .from("classroom")
+    .select("id, name")
+    .order("name", { ascending: true })
+    .returns<DashboardClassroom[]>();
+
+  if (error) {
+    console.error(error);
+  }
+
+  return NextResponse.json({ rows, error });
+}

--- a/app/debug/students/route.ts
+++ b/app/debug/students/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import type { Database } from "@/types/database";
+
+export const dynamic = "force-dynamic";
+
+type DashboardStudent = Pick<Database["public"]["Tables"]["student"]["Row"], "id" | "first_name" | "last_name">;
+
+export async function GET() {
+  const supabase = createServerSupabaseClient();
+  const { data: rows, error } = await supabase
+    .from("student")
+    .select("id, first_name, last_name")
+    .order("first_name", { ascending: true })
+    .returns<DashboardStudent[]>();
+
+  if (error) {
+    console.error(error);
+  }
+
+  return NextResponse.json({ rows, error });
+}


### PR DESCRIPTION
## Summary
- surface Supabase query failures on the dashboard with friendly error messages and console logging
- expose debug endpoints for classrooms and students reusing the dashboard queries

## Testing
- ⚠️ `npm run lint` *(interactive setup prompt prevents execution in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf474bfec48333983425a1425d2d70