### PR TITLE
feat: support guardian attendance view

### DIFF
--- a/app/attendance/page.tsx
+++ b/app/attendance/page.tsx
@@ -11,6 +11,7 @@ import {
   type AttendanceRole,
   type TypedSupabaseClient,
 } from "@/lib/attendance/client";
+import { setAttendanceDebugState } from "@/lib/attendance/debug-store";
 
 type Student = {
   id: string;
@@ -53,6 +54,39 @@ const STATUS_OPTIONS: { value: AttendanceStatus; label: string; description: str
   { value: "R", label: "R", description: "Retardo" },
 ];
 
+const GUARDIAN_ROLES = new Set<AttendanceRole>(["padre", "madre", "tutor"] as AttendanceRole[]);
+
+type GuardianStudent = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  fullName: string;
+};
+
+type AttendanceRow = Pick<
+  Database["public"]["Tables"]["attendance"]["Row"],
+  "id" | "status" | "note" | "date" | "classroom_id"
+>;
+
+type WithOptionalError = {
+  message?: string;
+  details?: string;
+  hint?: string;
+};
+
+function extractErrorMessage(error: unknown, fallback: string) {
+  if (error && typeof error === "object") {
+    const candidate = error as WithOptionalError;
+    if (candidate.message) return candidate.message;
+    if (candidate.details) return candidate.details;
+    if (candidate.hint) return candidate.hint;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback;
+}
+
 export default function AttendancePage() {
   const supabase = useMemo(() => createClientSupabaseClient(), []);
   const typedSupabase = supabase as unknown as TypedSupabaseClient;
@@ -68,8 +102,21 @@ export default function AttendancePage() {
   const [students, setStudents] = useState<Student[]>([]);
   const [attendance, setAttendance] = useState<Record<string, StudentAttendance>>({});
   const [saving, setSaving] = useState(false);
+  const [guardianStudents, setGuardianStudents] = useState<GuardianStudent[]>([]);
+  const [selectedGuardianStudent, setSelectedGuardianStudent] = useState<string | null>(null);
+  const [guardianAttendance, setGuardianAttendance] = useState<AttendanceRow | null>(null);
+  const [lastError, setLastError] = useState<string | null>(null);
 
   const canEdit = role === "director" || role === "teacher";
+  const isGuardian = role ? GUARDIAN_ROLES.has(role) : false;
+
+  useEffect(() => {
+    setAttendanceDebugState({ date });
+  }, [date]);
+
+  useEffect(() => {
+    setAttendanceDebugState({ lastError });
+  }, [lastError]);
 
   useEffect(() => {
     let ignore = false;
@@ -85,7 +132,10 @@ export default function AttendancePage() {
           throw userError;
         }
         if (!user) {
-          setFatalError("Inicia sesión para registrar asistencia.");
+          const message = "Inicia sesión para registrar asistencia.";
+          setFatalError(message);
+          setLastError(message);
+          setAttendanceDebugState({ lastError: message });
           return;
         }
         if (ignore) return;
@@ -102,22 +152,66 @@ export default function AttendancePage() {
         const currentRole = profile?.role ?? null;
         if (ignore) return;
         setRole(currentRole);
+        setAttendanceDebugState({ role: currentRole, classroomIds: [], childrenIds: [] });
 
-        const accessible = await fetchAccessibleClassrooms(
-          typedSupabase,
-          currentRole,
-          user.id,
-          profile?.school_id ?? null,
-        );
-        if (ignore) return;
-        setClassrooms(accessible);
-        if (accessible.length > 0) {
-          setSelectedClassroom(accessible[0].id);
+        if (currentRole && GUARDIAN_ROLES.has(currentRole)) {
+          const guardianTable = supabase.from("guardian") as any;
+          const { data: links, error: linksError } = await guardianTable
+            .select("student_id")
+            .eq("profile_id", user.id);
+          if (linksError) {
+            throw linksError;
+          }
+          const studentIds = (links ?? []).map((entry: { student_id: string }) => entry.student_id).filter(Boolean);
+          const { data: kids, error: kidsError } =
+            studentIds.length > 0
+              ? await supabase
+                  .from("student")
+                  .select("id, first_name, last_name")
+                  .in("id", studentIds)
+                  .returns<{ id: string; first_name: string; last_name: string }[]>()
+              : { data: [], error: null };
+          if (kidsError) {
+            throw kidsError;
+          }
+          if (ignore) return;
+          const formattedKids = (kids ?? [])
+            .map((kid) => ({
+              id: kid.id,
+              firstName: kid.first_name,
+              lastName: kid.last_name,
+              fullName: `${kid.first_name} ${kid.last_name}`.trim(),
+            }))
+            .sort((a, b) => a.fullName.localeCompare(b.fullName, "es", { sensitivity: "base" }));
+          setGuardianStudents(formattedKids);
+          setAttendanceDebugState({
+            childrenIds: formattedKids.map((kid) => kid.id),
+            classroomIds: [],
+          });
+          setSelectedGuardianStudent(formattedKids[0]?.id ?? null);
+        } else {
+          const accessible = await fetchAccessibleClassrooms(
+            typedSupabase,
+            currentRole,
+            user.id,
+            profile?.school_id ?? null,
+          );
+          if (ignore) return;
+          setClassrooms(accessible);
+          setAttendanceDebugState({
+            classroomIds: accessible.map((classroom) => classroom.id),
+            childrenIds: [],
+          });
+          setSelectedClassroom(accessible[0]?.id ?? null);
         }
+        setLastError(null);
+        setAttendanceDebugState({ lastError: null });
       } catch (err) {
         if (ignore) return;
-        const message = err instanceof Error ? err.message : "No fue posible cargar tus datos.";
+        const message = extractErrorMessage(err, "No fue posible cargar tus datos.");
         setFatalError(message);
+        setLastError(message);
+        setAttendanceDebugState({ lastError: message });
       } finally {
         if (!ignore) {
           setInitializing(false);
@@ -128,11 +222,48 @@ export default function AttendancePage() {
     return () => {
       ignore = true;
     };
-  }, [supabase]);
+  }, [supabase, typedSupabase]);
 
   useEffect(() => {
     let ignore = false;
     async function loadAttendance() {
+      if (isGuardian) {
+        if (!selectedGuardianStudent || !date) {
+          setGuardianAttendance(null);
+          return;
+        }
+        setRecordsLoading(true);
+        setFatalError(null);
+        setFormError(null);
+        setLastError(null);
+        try {
+          const { data, error } = await supabase
+            .from("attendance")
+            .select("id, status, note, date, classroom_id")
+            .eq("student_id", selectedGuardianStudent)
+            .eq("date", date)
+            .maybeSingle<AttendanceRow>();
+          if (error) {
+            throw error;
+          }
+          if (ignore) return;
+          setGuardianAttendance(data ?? null);
+          setLastError(null);
+          setAttendanceDebugState({ lastError: null });
+        } catch (err) {
+          if (ignore) return;
+          const message = extractErrorMessage(err, "No fue posible cargar la asistencia.");
+          setFatalError(message);
+          setLastError(message);
+          setAttendanceDebugState({ lastError: message });
+        } finally {
+          if (!ignore) {
+            setRecordsLoading(false);
+          }
+        }
+        return;
+      }
+
       if (!selectedClassroom || !date) {
         setStudents([]);
         setAttendance({});
@@ -141,6 +272,7 @@ export default function AttendancePage() {
       setRecordsLoading(true);
       setFatalError(null);
       setFormError(null);
+      setLastError(null);
       try {
         const { data: enrollmentData, error: enrollmentError } = await supabase
           .from("enrollment")
@@ -191,10 +323,14 @@ export default function AttendancePage() {
           };
         }
         setAttendance(map);
+        setLastError(null);
+        setAttendanceDebugState({ lastError: null });
       } catch (err) {
         if (ignore) return;
-        const message = err instanceof Error ? err.message : "No fue posible cargar la asistencia.";
+        const message = extractErrorMessage(err, "No fue posible cargar la asistencia.");
         setFatalError(message);
+        setLastError(message);
+        setAttendanceDebugState({ lastError: message });
       } finally {
         if (!ignore) {
           setRecordsLoading(false);
@@ -205,9 +341,12 @@ export default function AttendancePage() {
     return () => {
       ignore = true;
     };
-  }, [date, selectedClassroom, supabase]);
+  }, [date, isGuardian, selectedClassroom, selectedGuardianStudent, supabase]);
 
   const summary = useMemo(() => {
+    if (isGuardian) {
+      return { P: 0, A: 0, R: 0 } as Record<AttendanceStatus, number>;
+    }
     return students.reduce(
       (acc, student) => {
         const record = attendance[student.id];
@@ -218,7 +357,7 @@ export default function AttendancePage() {
       },
       { P: 0, A: 0, R: 0 } as Record<AttendanceStatus, number>,
     );
-  }, [attendance, students]);
+  }, [attendance, isGuardian, students]);
 
   const handleStatusChange = (studentId: string, status: AttendanceStatus) => {
     if (!canEdit) return;
@@ -301,9 +440,13 @@ export default function AttendancePage() {
         };
       }
       setAttendance(map);
+      setLastError(null);
+      setAttendanceDebugState({ lastError: null });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "No se pudo guardar la asistencia.";
+      const message = extractErrorMessage(err, "No se pudo guardar la asistencia.");
       setFormError(message);
+      setLastError(message);
+      setAttendanceDebugState({ lastError: message });
     } finally {
       setSaving(false);
     }
@@ -337,6 +480,71 @@ export default function AttendancePage() {
     URL.revokeObjectURL(url);
   };
 
+  const renderGuardianContent = () => {
+    if (guardianStudents.length === 0) {
+      return (
+        <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <p className="text-sm text-slate-600">
+            No se encontraron hijos vinculados a tu cuenta. Si crees que es un error, contacta a la dirección.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-6">
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div className="flex flex-col gap-2 md:flex-row md:items-end">
+              <label className="flex flex-col text-sm text-slate-600">
+                Alumno
+                <select
+                  className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-base focus:border-slate-500 focus:outline-none"
+                  value={selectedGuardianStudent ?? ""}
+                  onChange={(event) => setSelectedGuardianStudent(event.target.value)}
+                >
+                  {guardianStudents.map((student) => (
+                    <option key={student.id} value={student.id}>
+                      {student.fullName}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col text-sm text-slate-600">
+                Fecha
+                <input
+                  type="date"
+                  className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-base focus:border-slate-500 focus:outline-none"
+                  value={date}
+                  onChange={(event) => setDate(event.target.value)}
+                />
+              </label>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          {recordsLoading ? (
+            <p className="text-sm text-slate-500">Cargando asistencia...</p>
+          ) : guardianAttendance ? (
+            <div className="space-y-2 text-sm text-slate-700">
+              <p>
+                Estado: <span className="font-semibold">{guardianAttendance.status ?? ""}</span>
+              </p>
+              {guardianAttendance.note ? (
+                <p>
+                  Nota: <span>{guardianAttendance.note}</span>
+                </p>
+              ) : null}
+            </div>
+          ) : (
+            <p className="text-sm text-slate-600">Sin registro para esta fecha.</p>
+          )}
+        </section>
+      </div>
+    );
+  };
+
   const renderContent = () => {
     if (initializing) {
       return (
@@ -352,6 +560,10 @@ export default function AttendancePage() {
           {fatalError}
         </div>
       );
+    }
+
+    if (isGuardian) {
+      return renderGuardianContent();
     }
 
     if (classrooms.length === 0) {
@@ -494,9 +706,15 @@ export default function AttendancePage() {
     <main className="flex flex-1 flex-col gap-6">
       <header className="space-y-2">
         <h1 className="text-2xl font-semibold text-slate-900">Asistencia diaria</h1>
-        <p className="text-sm text-slate-600">
-          Marca la asistencia del salón seleccionado y agrega notas relevantes. Los cambios quedan registrados con tu usuario.
-        </p>
+        {isGuardian ? (
+          <p className="text-sm text-slate-600">
+            Consulta el registro de asistencia diario de tus hijos. Esta información es de solo lectura.
+          </p>
+        ) : (
+          <p className="text-sm text-slate-600">
+            Marca la asistencia del salón seleccionado y agrega notas relevantes. Los cambios quedan registrados con tu usuario.
+          </p>
+        )}
       </header>
       {renderContent()}
     </main>

--- a/app/debug/attendance/page.tsx
+++ b/app/debug/attendance/page.tsx
@@ -2,13 +2,18 @@
 
 export const dynamic = "force-dynamic";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { createClientSupabaseClient } from "@/lib/supabase/client";
 import {
   fetchAccessibleClassrooms,
+  type AttendanceClassroom,
   type AttendanceRole,
   type TypedSupabaseClient,
 } from "@/lib/attendance/client";
+import {
+  getAttendanceDebugState,
+  subscribeAttendanceDebugState,
+} from "@/lib/attendance/debug-store";
 import type { Database } from "@/types/database";
 
 type ProfileInfo = Pick<
@@ -25,31 +30,35 @@ type DebugState = {
   loading: boolean;
   userId: string | null;
   role: AttendanceRole | null;
-  classroomId: string | null;
-  date: string;
-  sampleRows: DebugAttendanceRow[] | null;
+  classroomsDisponibles: AttendanceClassroom[];
+  sampleQuery: DebugAttendanceRow[] | null;
   error: string | null;
+};
+
+const initialState: DebugState = {
+  loading: true,
+  userId: null,
+  role: null,
+  classroomsDisponibles: [],
+  sampleQuery: null,
+  error: null,
 };
 
 export default function DebugAttendancePage() {
   const supabase = useMemo(() => createClientSupabaseClient(), []);
   const typedSupabase = supabase as unknown as TypedSupabaseClient;
-  const defaultDate = useMemo(() => new Date().toISOString().slice(0, 10), []);
-  const [state, setState] = useState<DebugState>(() => ({
-    loading: true,
-    userId: null,
-    role: null,
-    classroomId: null,
-    date: defaultDate,
-    sampleRows: null,
-    error: null,
-  }));
+  const [state, setState] = useState<DebugState>(initialState);
+  const realtimeState = useSyncExternalStore(
+    subscribeAttendanceDebugState,
+    getAttendanceDebugState,
+    getAttendanceDebugState,
+  );
 
   useEffect(() => {
     let ignore = false;
     async function loadDebug() {
-      setState((prev) => ({ ...prev, loading: true, error: null }));
       try {
+        setState(initialState);
         const {
           data: { user },
           error: userError,
@@ -77,30 +86,22 @@ export default function DebugAttendancePage() {
           }
         }
 
-        let classroomId: string | null = null;
+        let classrooms: AttendanceClassroom[] = [];
         if (userId && role) {
           try {
-            const classrooms = await fetchAccessibleClassrooms(typedSupabase, role, userId, schoolId);
-            classroomId = classrooms[0]?.id ?? null;
+            classrooms = await fetchAccessibleClassrooms(typedSupabase, role, userId, schoolId);
           } catch (classroomError) {
             errorMessage = classroomError instanceof Error ? classroomError.message : String(classroomError);
           }
         }
 
-        let sampleRows: DebugAttendanceRow[] | null = null;
-        if (classroomId) {
-          const { data: sampleData, error: sampleError } = await supabase
-            .from("attendance")
-            .select("id, student_id, classroom_id, date, status, taken_by")
-            .eq("classroom_id", classroomId)
-            .eq("date", defaultDate)
-            .limit(5)
-            .returns<DebugAttendanceRow[]>();
-          if (sampleError) {
-            errorMessage = errorMessage ?? sampleError.message;
-          } else {
-            sampleRows = sampleData ?? [];
-          }
+        const { data: sampleData, error: sampleError } = await supabase
+          .from("attendance")
+          .select("id, student_id, classroom_id, date, status, taken_by")
+          .limit(5)
+          .returns<DebugAttendanceRow[]>();
+        if (sampleError && !errorMessage) {
+          errorMessage = sampleError.message;
         }
 
         if (ignore) return;
@@ -108,9 +109,8 @@ export default function DebugAttendancePage() {
           loading: false,
           userId,
           role,
-          classroomId,
-          date: defaultDate,
-          sampleRows,
+          classroomsDisponibles: classrooms,
+          sampleQuery: sampleData ?? null,
           error: errorMessage,
         });
       } catch (err) {
@@ -120,9 +120,8 @@ export default function DebugAttendancePage() {
           loading: false,
           userId: null,
           role: null,
-          classroomId: null,
-          date: defaultDate,
-          sampleRows: null,
+          classroomsDisponibles: [],
+          sampleQuery: null,
           error: message,
         });
       }
@@ -131,26 +130,41 @@ export default function DebugAttendancePage() {
     return () => {
       ignore = true;
     };
-  }, [defaultDate, supabase]);
+  }, [supabase, typedSupabase]);
+
+  const payload: Record<string, unknown> = {
+    role: realtimeState.role,
+    childrenIds: realtimeState.childrenIds,
+    classroomIds: realtimeState.classroomIds,
+    date: realtimeState.date,
+    lastError: realtimeState.lastError,
+  };
 
   return (
     <main className="flex flex-1 flex-col gap-6">
       <header>
         <h1 className="text-2xl font-semibold text-slate-900">Debug asistencia</h1>
         <p className="text-sm text-slate-600">
-          Información útil para revisar el alcance de las políticas RLS en la tabla de asistencia.
+          Información útil para revisar el alcance de las políticas RLS y el estado del cliente de asistencia.
         </p>
       </header>
       <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="mb-3 text-base font-semibold text-slate-800">Estado del cliente</h2>
+        <pre className="whitespace-pre-wrap text-sm text-slate-700">
+          {JSON.stringify(payload, null, 2)}
+        </pre>
+      </section>
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="mb-3 text-base font-semibold text-slate-800">Estado del servidor</h2>
         <pre className="whitespace-pre-wrap text-sm text-slate-700">
           {JSON.stringify(
             {
               userId: state.userId,
               role: state.role,
-              classroomId: state.classroomId,
-              date: state.date,
-              sampleRows: state.sampleRows,
+              classroomsDisponibles: state.classroomsDisponibles,
+              sampleQuery: state.sampleQuery,
               error: state.error,
+              loading: state.loading,
             },
             null,
             2,

--- a/lib/attendance/debug-store.ts
+++ b/lib/attendance/debug-store.ts
@@ -1,0 +1,39 @@
+import type { AttendanceRole } from "@/lib/attendance/client";
+
+type AttendanceDebugState = {
+  role: AttendanceRole | null;
+  classroomIds: string[];
+  childrenIds: string[];
+  date: string | null;
+  lastError: string | null;
+};
+
+type Listener = (state: AttendanceDebugState) => void;
+
+const listeners = new Set<Listener>();
+
+let state: AttendanceDebugState = {
+  role: null,
+  classroomIds: [],
+  childrenIds: [],
+  date: null,
+  lastError: null,
+};
+
+export function getAttendanceDebugState() {
+  return state;
+}
+
+export function setAttendanceDebugState(update: Partial<AttendanceDebugState>) {
+  state = { ...state, ...update };
+  for (const listener of listeners) {
+    listener(state);
+  }
+}
+
+export function subscribeAttendanceDebugState(listener: Listener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}


### PR DESCRIPTION
## Summary
- detect guardian roles in the attendance page and load a read-only child/date view with clearer error handling
- keep the existing editing workflow for teachers/directors while publishing attendance debug info through a shared client store
- expose `/debug/attendance` with live client state (role, children/classrooms, date, last error) plus the original server-side diagnostics

## Testing
- npm run lint *(fails: interactive Next.js lint configuration prompt appears in the container)*

## Vercel Preview
1. Deploy the branch to Vercel.
2. **Padre/Madre/Tutor**: log in with a guardian account, open `/attendance`, choose a hijo and fecha, and confirm the read-only asistencia data (or "Sin registro para esta fecha").
3. **Maestra/Director**: log in with a docente account, open `/attendance`, select salón and fecha, and confirm the editable attendance flow still works.
4. Visit `/debug/attendance` while browsing as either role to review the reported `{ role, childrenIds/classroomIds, date, lastError }` values.


------
https://chatgpt.com/codex/tasks/task_e_68cf4f1638708333a9566be8d8fb6999