### PR TITLE
Implement guardian attendance view with profile-based guardian links

### DIFF
--- a/sql/attendance.sql
+++ b/sql/attendance.sql
@@ -42,7 +42,7 @@ drop policy if exists att_sel_parent on public.attendance;
 create policy att_sel_parent on public.attendance
   for select using (
     exists (select 1 from public.guardian g
-            where g.user_id = auth.uid()
+            where g.profile_id = auth.uid()
               and g.student_id = attendance.student_id)
   );
 -- INSERT / UPDATE (director o maestra asignada)

--- a/supabase/bootstrap.sql
+++ b/supabase/bootstrap.sql
@@ -27,7 +27,7 @@ create table public.school (
 create table public.user_profile (
   id uuid primary key references auth.users (id) on delete cascade,
   display_name text,
-  role text not null default 'parent' check (role in ('director', 'teacher', 'parent')),
+  role text not null default 'parent' check (role in ('director', 'teacher', 'maestra', 'padre', 'madre', 'tutor', 'parent')),
   school_id uuid references public.school (id) on delete set null,
   created_at timestamptz not null default timezone('utc'::text, now())
 );
@@ -54,14 +54,14 @@ create index student_school_idx on public.student (school_id);
 
 create table public.guardian (
   id uuid primary key default gen_random_uuid(),
-  user_id uuid not null references public.user_profile (id) on delete cascade,
+  profile_id uuid not null references public.user_profile (id) on delete cascade,
   student_id uuid not null references public.student (id) on delete cascade,
   relationship text,
   created_at timestamptz not null default timezone('utc'::text, now()),
-  unique (user_id, student_id)
+  unique (profile_id, student_id)
 );
 
-create index guardian_user_idx on public.guardian (user_id);
+create index guardian_profile_idx on public.guardian (profile_id);
 create index guardian_student_idx on public.guardian (student_id);
 
 create table public.enrollment (
@@ -176,7 +176,7 @@ create policy "Guardians read their students" on public.student
     exists (
       select 1
       from public.guardian g
-      where g.user_id = auth.uid()
+      where g.profile_id = auth.uid()
         and g.student_id = student.id
     )
   );
@@ -196,7 +196,7 @@ create policy "Directors read guardians" on public.guardian
 
 create policy "Guardians read themselves" on public.guardian
   for select
-  using (guardian.user_id = auth.uid());
+  using (guardian.profile_id = auth.uid());
 
 create policy "Directors read enrollments" on public.enrollment
   for select

--- a/supabase/migrations/20240219180000_initial.sql
+++ b/supabase/migrations/20240219180000_initial.sql
@@ -21,7 +21,7 @@ create table public.school (
 create table public.user_profile (
   id uuid primary key references auth.users (id) on delete cascade,
   display_name text,
-  role text not null default 'parent' check (role in ('director', 'teacher', 'parent')),
+  role text not null default 'parent' check (role in ('director', 'teacher', 'maestra', 'padre', 'madre', 'tutor', 'parent')),
   school_id uuid references public.school (id) on delete set null,
   created_at timestamptz not null default timezone('utc'::text, now())
 );
@@ -48,14 +48,14 @@ create index student_school_idx on public.student (school_id);
 
 create table public.guardian (
   id uuid primary key default gen_random_uuid(),
-  user_id uuid not null references public.user_profile (id) on delete cascade,
+  profile_id uuid not null references public.user_profile (id) on delete cascade,
   student_id uuid not null references public.student (id) on delete cascade,
   relationship text,
   created_at timestamptz not null default timezone('utc'::text, now()),
-  unique (user_id, student_id)
+  unique (profile_id, student_id)
 );
 
-create index guardian_user_idx on public.guardian (user_id);
+create index guardian_profile_idx on public.guardian (profile_id);
 create index guardian_student_idx on public.guardian (student_id);
 
 create table public.enrollment (
@@ -170,7 +170,7 @@ create policy "Guardians read their students" on public.student
     exists (
       select 1
       from public.guardian g
-      where g.user_id = auth.uid()
+      where g.profile_id = auth.uid()
         and g.student_id = student.id
     )
   );
@@ -190,7 +190,7 @@ create policy "Directors read guardians" on public.guardian
 
 create policy "Guardians read themselves" on public.guardian
   for select
-  using (guardian.user_id = auth.uid());
+  using (guardian.profile_id = auth.uid());
 
 create policy "Directors read enrollments" on public.enrollment
   for select

--- a/types/database.ts
+++ b/types/database.ts
@@ -150,21 +150,21 @@ export interface Database {
           id: string;
           relationship: string | null;
           student_id: string;
-          user_id: string;
+          profile_id: string;
         };
         Insert: {
           created_at?: string | null;
           id?: string;
           relationship?: string | null;
           student_id: string;
-          user_id: string;
+          profile_id: string;
         };
         Update: {
           created_at?: string | null;
           id?: string;
           relationship?: string | null;
           student_id?: string;
-          user_id?: string;
+          profile_id?: string;
         };
         Relationships: [
           {
@@ -174,8 +174,8 @@ export interface Database {
             referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "guardian_user_id_fkey";
-            columns: ["user_id"];
+            foreignKeyName: "guardian_profile_id_fkey";
+            columns: ["profile_id"];
             referencedRelation: "user_profile";
             referencedColumns: ["id"];
           }
@@ -272,21 +272,42 @@ export interface Database {
           created_at: string | null;
           display_name: string | null;
           id: string;
-          role: "director" | "teacher" | "parent";
+          role:
+            | "director"
+            | "teacher"
+            | "maestra"
+            | "padre"
+            | "madre"
+            | "tutor"
+            | "parent";
           school_id: string | null;
         };
         Insert: {
           created_at?: string | null;
           display_name?: string | null;
           id: string;
-          role?: "director" | "teacher" | "parent";
+          role?:
+            | "director"
+            | "teacher"
+            | "maestra"
+            | "padre"
+            | "madre"
+            | "tutor"
+            | "parent";
           school_id?: string | null;
         };
         Update: {
           created_at?: string | null;
           display_name?: string | null;
           id?: string;
-          role?: "director" | "teacher" | "parent";
+          role?:
+            | "director"
+            | "teacher"
+            | "maestra"
+            | "padre"
+            | "madre"
+            | "tutor"
+            | "parent";
           school_id?: string | null;
         };
         Relationships: [


### PR DESCRIPTION
## Summary
- update the attendance page to load guardian profiles, fetch children via `guardian.profile_id`, and render a read-only attendance card for parents and tutors
- refresh the debug attendance page to surface the guardian-specific client state alongside existing server information
- align the attendance client utilities, database types, and SQL policies with the new guardian profile identifier and expanded role list

## Testing
- `npm run lint` *(blocked by interactive Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68cf543d58408333932661afd603955d