### PR TITLE
feat: add messages module with threads and RLS

### DIFF
--- a/README_messages.md
+++ b/README_messages.md
@@ -1,0 +1,26 @@
+# Módulo de mensajes y avisos
+
+Este módulo agrega las tablas `message_thread` y `message` para publicar avisos generales y por salón. A continuación se describen los pasos para aplicar los cambios en la base de datos y cómo probar los flujos principales para cada rol.
+
+## Aplicar `sql/messages.sql`
+
+1. Asegúrate de tener configurada la CLI de Supabase y acceso a la base de datos del proyecto.
+2. Ejecuta el script con cualquiera de las siguientes opciones:
+   - Usando la CLI de Supabase en tu entorno local: `supabase db execute --file sql/messages.sql`
+   - Usando `psql` directamente contra la base de datos: `psql "$SUPABASE_DB_URL" -f sql/messages.sql`
+3. Verifica que las nuevas tablas e índices existan y que las políticas RLS se hayan creado correctamente.
+
+## Pruebas manuales por rol
+
+1. Inicia sesión en la app (`npm run dev` y abre `http://localhost:3000`).
+2. Para cada rol utiliza cuentas con permisos apropiados y valida lo siguiente:
+   - **Director**: puede ver todos los hilos desde `/messages`, crear avisos generales o por salón desde `/messages/new` y responder en cualquier hilo.
+   - **Maestra/teacher**: ve los hilos de sus salones (y los avisos generales), puede crear avisos para los salones asignados y responder en ellos.
+   - **Padre/madre/tutor**: solo visualiza los hilos del salón donde está su hijo y puede responder desde `/messages/[id]`.
+3. Usa `/debug/messages` para revisar un resumen `{ role, threadsCount, sampleThread, lastError }` y validar que RLS esté devolviendo datos.
+4. Opcional: verifica que las páginas manejen mensajes de error cuando el usuario intenta realizar acciones sin permisos.
+
+## Consideraciones adicionales
+
+- Todos los formularios usan acciones del servidor de Next.js; al enviar un mensaje exitoso la página se refresca automáticamente.
+- Las políticas RLS permiten que directores y maestras publiquen avisos, y que tutores respondan únicamente en hilos del salón correspondiente.

--- a/app/attendance/page.tsx
+++ b/app/attendance/page.tsx
@@ -69,7 +69,7 @@ export default function AttendancePage() {
   const [attendance, setAttendance] = useState<Record<string, StudentAttendance>>({});
   const [saving, setSaving] = useState(false);
 
-  const canEdit = role === "director" || role === "teacher";
+  const canEdit = role === "director" || role === "teacher" || role === "maestra";
 
   useEffect(() => {
     let ignore = false;

--- a/app/debug/messages/page.tsx
+++ b/app/debug/messages/page.tsx
@@ -1,0 +1,77 @@
+import { redirect } from "next/navigation";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export default async function DebugMessagesPage() {
+  const supabase = createServerSupabaseClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  let role: string | null = null;
+  let threadsCount: number | null = null;
+  let sampleThread: unknown = null;
+  let lastError: string | null = null;
+
+  try {
+    const { data: profile, error: profileError } = await supabase
+      .from("user_profile")
+      .select("role")
+      .eq("id", session.user.id)
+      .maybeSingle<{ role: string | null }>();
+    if (profileError) {
+      throw profileError;
+    }
+    role = profile?.role ?? null;
+
+    const { count, error: countError } = await supabase
+      .from("message_thread")
+      .select("id", { count: "exact", head: true });
+    if (countError) {
+      throw countError;
+    }
+    threadsCount = count ?? 0;
+
+    const { data: sample, error: sampleError } = await supabase
+      .from("message_thread")
+      .select("id, title, classroom_id, created_at")
+      .order("created_at", { ascending: false })
+      .limit(1);
+    if (sampleError) {
+      throw sampleError;
+    }
+    sampleThread = sample?.[0] ?? null;
+  } catch (error) {
+    lastError = error instanceof Error ? error.message : String(error);
+  }
+
+  return (
+    <main className="flex flex-1 flex-col gap-6">
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-semibold">Debug mensajes</h1>
+        <p className="mt-2 text-sm text-slate-500">
+          Información resumida para validar el acceso a los avisos y mensajes por salón.
+        </p>
+      </section>
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <pre className="whitespace-pre-wrap text-sm text-slate-700">
+          {JSON.stringify(
+            {
+              role,
+              threadsCount,
+              sampleThread,
+              lastError,
+            },
+            null,
+            2,
+          )}
+        </pre>
+      </section>
+    </main>
+  );
+}

--- a/app/messages/NewThreadForm.tsx
+++ b/app/messages/NewThreadForm.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, type FormHTMLAttributes } from "react";
+import { useFormStatus } from "react-dom";
+
+type ClassroomOption = {
+  id: string;
+  name: string;
+};
+
+type ThreadType = "general" | "classroom";
+
+type NewThreadFormProps = {
+  classrooms: ClassroomOption[];
+  action: FormHTMLAttributes<HTMLFormElement>["action"];
+  errorMessage?: string | null;
+  allowGeneral: boolean;
+};
+
+const TYPES: { value: ThreadType; label: string }[] = [
+  { value: "general", label: "Aviso general de escuela" },
+  { value: "classroom", label: "Aviso por salón" },
+];
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="mt-4 inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+    >
+      {pending ? "Guardando..." : "Publicar aviso"}
+    </button>
+  );
+}
+
+export function NewThreadForm({ classrooms, action, errorMessage, allowGeneral }: NewThreadFormProps) {
+  const typeOptions = allowGeneral ? TYPES : TYPES.filter((option) => option.value !== "general");
+  const [type, setType] = useState<ThreadType>(() => (allowGeneral ? "general" : "classroom"));
+  const showClassroomSelect = type === "classroom";
+
+  return (
+    <form action={action} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-slate-700" htmlFor="type">
+          Tipo de aviso
+        </label>
+        <select
+          id="type"
+          name="type"
+          className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          value={type}
+          onChange={(event) => setType(event.target.value as ThreadType)}
+        >
+          {typeOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {showClassroomSelect ? (
+        <div>
+          <label className="block text-sm font-medium text-slate-700" htmlFor="classroomId">
+            Salón
+          </label>
+          <select
+            id="classroomId"
+            name="classroomId"
+            required
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          >
+            <option value="">Selecciona un salón</option>
+            {classrooms.map((classroom) => (
+              <option key={classroom.id} value={classroom.id}>
+                {classroom.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : null}
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700" htmlFor="title">
+          Título del aviso
+        </label>
+        <input
+          id="title"
+          name="title"
+          required
+          minLength={3}
+          className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          placeholder="Ej. Reunión de padres"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700" htmlFor="body">
+          Primer mensaje
+        </label>
+        <textarea
+          id="body"
+          name="body"
+          required
+          rows={4}
+          minLength={5}
+          className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          placeholder="Escribe el detalle del aviso"
+        />
+      </div>
+
+      {errorMessage ? (
+        <p className="text-sm text-rose-600">{errorMessage}</p>
+      ) : null}
+
+      <SubmitButton />
+    </form>
+  );
+}

--- a/app/messages/[id]/page.tsx
+++ b/app/messages/[id]/page.tsx
@@ -1,0 +1,257 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+type ThreadDetails = {
+  id: string;
+  title: string;
+  created_at: string;
+  classroom_id: string | null;
+  school_id: string;
+  classroom: { name: string } | null;
+};
+
+type MessageRow = {
+  id: string;
+  body: string;
+  created_at: string;
+  sender: { id: string; display_name: string | null; role: string | null } | null;
+};
+
+type SearchParams = {
+  error?: string;
+};
+
+function isTeacherRole(role: string | null): boolean {
+  return role === "teacher" || role === "maestra";
+}
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleString("es-MX", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+export default async function MessageThreadPage({
+  params,
+  searchParams,
+}: {
+  params: { id: string };
+  searchParams?: SearchParams;
+}) {
+  const supabase = createServerSupabaseClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  const { data: thread } = await supabase
+    .from("message_thread")
+    .select(
+      "id, title, created_at, classroom_id, school_id, classroom:classroom_id (name)",
+    )
+    .eq("id", params.id)
+    .maybeSingle<ThreadDetails>();
+
+  if (!thread) {
+    redirect("/messages");
+  }
+
+  const { data: profile } = await supabase
+    .from("user_profile")
+    .select("role, school_id")
+    .eq("id", session.user.id)
+    .maybeSingle<{ role: string | null; school_id: string | null }>();
+
+  const { data: guardianRows } = await supabase
+    .from("guardian")
+    .select("student_id")
+    .eq("user_id", session.user.id);
+
+  let guardianCanPost = false;
+  const studentIds = (guardianRows ?? []).map((row) => row.student_id);
+  if (thread.classroom_id && studentIds.length) {
+    const { data: enrollmentRows } = await supabase
+      .from("enrollment")
+      .select("id")
+      .eq("classroom_id", thread.classroom_id)
+      .in("student_id", studentIds)
+      .limit(1);
+    guardianCanPost = (enrollmentRows ?? []).length > 0;
+  }
+
+  const schoolMatches =
+    profile?.school_id && thread.school_id && profile.school_id === thread.school_id;
+
+  const canPost =
+    (schoolMatches && (profile?.role === "director" || isTeacherRole(profile?.role ?? null))) ||
+    guardianCanPost;
+
+  const { data: messages } = await supabase
+    .from("message")
+    .select("id, body, created_at, sender:sender_id (id, display_name, role)")
+    .eq("thread_id", thread.id)
+    .order("created_at", { ascending: true })
+    .returns<MessageRow[]>();
+
+  const errorMessage = searchParams?.error ?? null;
+
+  async function sendMessage(formData: FormData) {
+    "use server";
+
+    const serverClient = createServerSupabaseClient();
+    const {
+      data: { session: serverSession },
+    } = await serverClient.auth.getSession();
+
+    if (!serverSession) {
+      redirect("/login");
+    }
+
+    const body = String(formData.get("body") ?? "").trim();
+
+    if (!body || body.length < 1) {
+      redirect(`/messages/${params.id}?error=${encodeURIComponent("Escribe un mensaje para enviar.")}`);
+    }
+
+    const { data: serverProfile, error: serverProfileError } = await serverClient
+      .from("user_profile")
+      .select("role, school_id")
+      .eq("id", serverSession.user.id)
+      .maybeSingle<{ role: string | null; school_id: string | null }>();
+
+    if (serverProfileError) {
+      redirect(`/messages/${params.id}?error=${encodeURIComponent("No fue posible validar tu perfil.")}`);
+    }
+
+    const { data: serverThread } = await serverClient
+      .from("message_thread")
+      .select("id, classroom_id, school_id")
+      .eq("id", params.id)
+      .maybeSingle<{ id: string; classroom_id: string | null; school_id: string }>();
+
+    if (!serverThread) {
+      redirect("/messages");
+    }
+
+    const schoolAllowed =
+      serverProfile?.school_id &&
+      serverProfile.school_id === serverThread.school_id &&
+      (serverProfile.role === "director" || isTeacherRole(serverProfile.role ?? null));
+
+    let guardianAllowed = false;
+    if (!schoolAllowed && serverThread.classroom_id) {
+      const { data: serverGuardianRows } = await serverClient
+        .from("guardian")
+        .select("student_id")
+        .eq("user_id", serverSession.user.id);
+      const guardianStudentIds = (serverGuardianRows ?? []).map((row) => row.student_id);
+      if (guardianStudentIds.length) {
+        const { data: serverEnrollmentRows } = await serverClient
+          .from("enrollment")
+          .select("id")
+          .eq("classroom_id", serverThread.classroom_id)
+          .in("student_id", guardianStudentIds)
+          .limit(1);
+        guardianAllowed = (serverEnrollmentRows ?? []).length > 0;
+      }
+    }
+
+    if (!schoolAllowed && !guardianAllowed) {
+      redirect(`/messages/${params.id}?error=${encodeURIComponent("No puedes responder en este hilo.")}`);
+    }
+
+    const { error: insertError } = await serverClient.from("message").insert({
+      thread_id: serverThread.id,
+      sender_id: serverSession.user.id,
+      body,
+    });
+
+    if (insertError) {
+      redirect(`/messages/${params.id}?error=${encodeURIComponent("No se pudo enviar tu mensaje.")}`);
+    }
+
+    redirect(`/messages/${params.id}`);
+  }
+
+  return (
+    <main className="flex flex-1 flex-col gap-6">
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600">
+              {thread.classroom?.name ? `Salón: ${thread.classroom.name}` : "Aviso general"}
+            </p>
+            <h1 className="mt-1 text-2xl font-semibold text-slate-900">{thread.title}</h1>
+            <p className="mt-2 text-sm text-slate-500">Creado el {formatDate(thread.created_at)}</p>
+          </div>
+          <Link
+            href="/messages"
+            className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-indigo-200 hover:text-indigo-600"
+          >
+            Volver a la lista
+          </Link>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Mensajes</h2>
+        <div className="mt-4 space-y-4">
+          {messages?.length ? (
+            messages.map((message) => (
+              <article key={message.id} className="rounded border border-slate-100 p-4">
+                <div className="flex items-center justify-between text-xs text-slate-500">
+                  <span className="font-medium text-slate-700">
+                    {message.sender?.display_name ?? "Usuario"} ({message.sender?.role ?? "rol desconocido"})
+                  </span>
+                  <span>{formatDate(message.created_at)}</span>
+                </div>
+                <p className="mt-2 text-sm text-slate-700 whitespace-pre-line">{message.body}</p>
+              </article>
+            ))
+          ) : (
+            <p className="text-sm text-slate-500">Aún no hay mensajes en este hilo.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Responder</h2>
+        {errorMessage ? <p className="mb-3 text-sm text-rose-600">{errorMessage}</p> : null}
+        {canPost ? (
+          <form action={sendMessage} className="space-y-3">
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="body">
+                Tu mensaje
+              </label>
+              <textarea
+                id="body"
+                name="body"
+                required
+                rows={4}
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                placeholder="Escribe tu respuesta"
+              />
+            </div>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700"
+            >
+              Enviar mensaje
+            </button>
+          </form>
+        ) : (
+          <p className="text-sm text-slate-500">
+            No tienes permisos para responder en este hilo, pero puedes leer los mensajes anteriores.
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/app/messages/new/page.tsx
+++ b/app/messages/new/page.tsx
@@ -1,0 +1,261 @@
+import { redirect } from "next/navigation";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { NewThreadForm } from "../NewThreadForm";
+
+export const dynamic = "force-dynamic";
+
+type ClassroomOption = {
+  id: string;
+  name: string;
+};
+
+type SearchParams = {
+  error?: string;
+};
+
+function encodeError(message: string) {
+  return `/messages/new?error=${encodeURIComponent(message)}`;
+}
+
+function isTeacherRole(role: string | null): boolean {
+  return role === "teacher" || role === "maestra";
+}
+
+async function getAccessibleClassrooms(
+  supabase: ReturnType<typeof createServerSupabaseClient>,
+  role: string | null,
+  userId: string,
+  schoolId: string | null,
+): Promise<ClassroomOption[]> {
+  if (!role || !schoolId) {
+    return [];
+  }
+
+  if (role === "director") {
+    const { data, error } = await supabase
+      .from("classroom")
+      .select("id, name")
+      .eq("school_id", schoolId)
+      .order("name", { ascending: true });
+    if (error) {
+      throw error;
+    }
+    return data ?? [];
+  }
+
+  if (isTeacherRole(role)) {
+    const { data, error } = await supabase
+      .from("teacher_classroom")
+      .select("classroom:classroom_id (id, name)")
+      .eq("teacher_id", userId);
+    if (error) {
+      throw error;
+    }
+    const map = new Map<string, ClassroomOption>();
+    for (const row of data ?? []) {
+      const classroom = row.classroom as { id: string; name: string } | null;
+      if (classroom) {
+        map.set(classroom.id, classroom);
+      }
+    }
+    return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name, "es", { sensitivity: "base" }));
+  }
+
+  const { data, error } = await supabase
+    .from("guardian")
+    .select("student_id")
+    .eq("user_id", userId);
+  if (error) {
+    throw error;
+  }
+  const studentIds = (data ?? []).map((row) => row.student_id);
+  if (!studentIds.length) {
+    return [];
+  }
+  const { data: enrollments, error: enrollmentError } = await supabase
+    .from("enrollment")
+    .select("classroom:classroom_id (id, name)")
+    .eq("school_id", schoolId)
+    .in("student_id", studentIds);
+  if (enrollmentError) {
+    throw enrollmentError;
+  }
+  const map = new Map<string, ClassroomOption>();
+  for (const row of enrollments ?? []) {
+    const classroom = row.classroom as { id: string; name: string } | null;
+    if (classroom) {
+      map.set(classroom.id, classroom);
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name, "es", { sensitivity: "base" }));
+}
+
+export default async function NewMessagePage({ searchParams }: { searchParams?: SearchParams }) {
+  const supabase = createServerSupabaseClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  const { data: profile } = await supabase
+    .from("user_profile")
+    .select("role, school_id")
+    .eq("id", session.user.id)
+    .maybeSingle<{ role: string | null; school_id: string | null }>();
+
+  const role = profile?.role ?? null;
+  const schoolId = profile?.school_id ?? null;
+
+  const canCreate = role === "director" || isTeacherRole(role);
+
+  if (!canCreate) {
+    return (
+      <main className="flex flex-1 flex-col gap-6">
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold">Nuevo aviso</h1>
+          <p className="mt-2 text-sm text-slate-500">
+            Solo directores y maestras pueden crear avisos.
+          </p>
+          <p className="mt-4 text-sm text-slate-500">
+            Puedes regresar a la lista de avisos desde{" "}
+            <a href="/messages" className="font-medium text-indigo-600 hover:underline">
+              mensajes y avisos
+            </a>
+            .
+          </p>
+        </section>
+      </main>
+    );
+  }
+
+  const classrooms = await getAccessibleClassrooms(supabase, role, session.user.id, schoolId);
+  const errorMessage = searchParams?.error ?? null;
+  const allowGeneral = role === "director";
+
+  async function createThread(formData: FormData) {
+    "use server";
+
+    const serverClient = createServerSupabaseClient();
+    const {
+      data: { session: serverSession },
+    } = await serverClient.auth.getSession();
+
+    if (!serverSession) {
+      redirect("/login");
+    }
+
+    const type = String(formData.get("type") ?? "");
+    const title = String(formData.get("title") ?? "").trim();
+    const body = String(formData.get("body") ?? "").trim();
+    const classroomIdValue = formData.get("classroomId");
+
+    if (!title || title.length < 3) {
+      redirect(encodeError("El título debe tener al menos 3 caracteres."));
+    }
+
+    if (!body || body.length < 5) {
+      redirect(encodeError("El mensaje debe tener al menos 5 caracteres."));
+    }
+
+    const { data: serverProfile, error: profileError } = await serverClient
+      .from("user_profile")
+      .select("role, school_id")
+      .eq("id", serverSession.user.id)
+      .maybeSingle<{ role: string | null; school_id: string | null }>();
+
+    if (profileError) {
+      redirect(encodeError("No fue posible validar tu perfil."));
+    }
+
+    const currentRole = serverProfile?.role ?? null;
+    const currentSchoolId = serverProfile?.school_id ?? null;
+
+    if (!currentRole || !currentSchoolId) {
+      redirect(encodeError("Necesitas pertenecer a una escuela para publicar avisos."));
+    }
+
+    if (currentRole !== "director" && !isTeacherRole(currentRole)) {
+      redirect(encodeError("No tienes permisos para crear avisos."));
+    }
+
+    const allowedClassrooms = await getAccessibleClassrooms(
+      serverClient,
+      currentRole,
+      serverSession.user.id,
+      currentSchoolId,
+    );
+
+    let classroomId: string | null = null;
+
+    if (type === "classroom") {
+      const selected = typeof classroomIdValue === "string" ? classroomIdValue : "";
+      if (!selected) {
+        redirect(encodeError("Selecciona un salón para el aviso."));
+      }
+      if (!allowedClassrooms.some((classroom) => classroom.id === selected)) {
+        redirect(encodeError("No tienes acceso a ese salón."));
+      }
+      classroomId = selected;
+    } else if (type === "general") {
+      if (currentRole !== "director") {
+        redirect(encodeError("Solo la dirección puede crear avisos generales."));
+      }
+    } else {
+      redirect(encodeError("Selecciona un tipo de aviso válido."));
+    }
+
+    const { data: thread, error: threadError } = await serverClient
+      .from("message_thread")
+      .insert({
+        school_id: currentSchoolId,
+        classroom_id: classroomId,
+        title,
+        created_by: serverSession.user.id,
+      })
+      .select("id")
+      .single();
+
+    if (threadError || !thread) {
+      redirect(encodeError("No fue posible crear el aviso."));
+    }
+
+    const { error: messageError } = await serverClient.from("message").insert({
+      thread_id: thread.id,
+      sender_id: serverSession.user.id,
+      body,
+    });
+
+    if (messageError) {
+      redirect(encodeError("El aviso se creó sin mensaje. Intenta nuevamente."));
+    }
+
+    redirect(`/messages/${thread.id}`);
+  }
+
+  return (
+    <main className="flex flex-1 flex-col gap-6">
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-semibold">Nuevo aviso</h1>
+        <p className="mt-2 text-sm text-slate-500">
+          Crea un nuevo hilo de mensajes para compartir información con tu comunidad escolar.
+        </p>
+        <div className="mt-6">
+          {!allowGeneral && classrooms.length === 0 ? (
+            <p className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+              No tienes salones asignados actualmente. Comunícate con la dirección si necesitas acceso para publicar avisos.
+            </p>
+          ) : null}
+          <NewThreadForm
+            classrooms={classrooms}
+            action={createThread}
+            errorMessage={errorMessage}
+            allowGeneral={allowGeneral}
+          />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+type ThreadListItem = {
+  id: string;
+  title: string;
+  created_at: string;
+  classroom: { name: string } | null;
+  messages: { body: string; created_at: string }[] | null;
+};
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleString("es-MX", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+export default async function MessagesPage() {
+  const supabase = createServerSupabaseClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  const { data: threads } = await supabase
+    .from("message_thread")
+    .select(
+      "id, title, created_at, classroom:classroom_id(name), messages:message(order=created_at.desc,limit=1)(body, created_at)",
+    )
+    .order("created_at", { ascending: false })
+    .returns<ThreadListItem[]>();
+
+  return (
+    <main className="flex flex-1 flex-col gap-6">
+      <section className="flex items-center justify-between rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div>
+          <h1 className="text-2xl font-semibold">Mensajes y avisos</h1>
+          <p className="mt-2 text-sm text-slate-500">
+            Consulta los avisos generales de la escuela y los mensajes por salón.
+          </p>
+        </div>
+        <Link
+          href="/messages/new"
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700"
+        >
+          Nuevo aviso
+        </Link>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Hilos disponibles</h2>
+        <p className="mt-2 text-sm text-slate-500">
+          Solo se muestran los hilos que puedes ver según tus permisos.
+        </p>
+        <ul className="mt-4 space-y-3">
+          {threads?.length ? (
+            threads.map((thread) => {
+              const lastMessage = thread.messages?.[0] ?? null;
+              return (
+                <li key={thread.id} className="rounded border border-slate-100 p-4 transition hover:border-indigo-200">
+                  <Link href={`/messages/${thread.id}`} className="flex flex-col gap-2">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm font-medium uppercase tracking-wide text-indigo-600">
+                          {thread.classroom?.name ? `Salón: ${thread.classroom.name}` : "Aviso general"}
+                        </p>
+                        <h3 className="text-lg font-semibold text-slate-900">{thread.title}</h3>
+                      </div>
+                      <span className="text-xs text-slate-500">{formatDate(thread.created_at)}</span>
+                    </div>
+                    {lastMessage ? (
+                      <p className="text-sm text-slate-600">
+                        {lastMessage.body}
+                      </p>
+                    ) : (
+                      <p className="text-sm italic text-slate-400">Sin mensajes</p>
+                    )}
+                  </Link>
+                </li>
+              );
+            })
+          ) : (
+            <li className="rounded border border-dashed border-slate-200 p-4 text-sm text-slate-400">
+              No hay avisos disponibles por el momento.
+            </li>
+          )}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/lib/attendance/client.ts
+++ b/lib/attendance/client.ts
@@ -35,7 +35,7 @@ export async function fetchAccessibleClassrooms(
     return data ?? [];
   }
 
-  if (role === "teacher") {
+  if (role === "teacher" || role === "maestra") {
     const { data, error } = await supabase
       .from("teacher_classroom")
       .select("classroom:classroom_id (id, name)")

--- a/sql/messages.sql
+++ b/sql/messages.sql
@@ -1,0 +1,153 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.message_thread (
+  id uuid primary key default gen_random_uuid(),
+  school_id uuid not null references public.school(id) on delete cascade,
+  classroom_id uuid references public.classroom(id) on delete set null,
+  title text not null,
+  created_by uuid not null references public.user_profile(id),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.message (
+  id uuid primary key default gen_random_uuid(),
+  thread_id uuid not null references public.message_thread(id) on delete cascade,
+  sender_id uuid not null references public.user_profile(id),
+  body text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_message_thread_school on public.message_thread(school_id, classroom_id);
+create index if not exists idx_message_thread_created on public.message_thread(created_at desc);
+create index if not exists idx_message_thread_id on public.message(thread_id, created_at);
+
+alter table public.message_thread enable row level security;
+drop policy if exists mt_sel on public.message_thread;
+create policy mt_sel on public.message_thread
+for select using (
+  exists (
+    select 1
+    from public.user_profile me
+    where me.id = auth.uid()
+      and me.role = 'director'
+      and me.school_id = message_thread.school_id
+  )
+  or exists (
+    select 1
+    from public.teacher_classroom tc
+    where tc.teacher_id = auth.uid()
+      and tc.classroom_id = message_thread.classroom_id
+  )
+  or exists (
+    select 1
+    from public.guardian g
+    join public.enrollment e on e.student_id = g.student_id
+    where g.user_id = auth.uid()
+      and e.classroom_id = message_thread.classroom_id
+  )
+  or (
+    message_thread.classroom_id is null
+    and exists (
+      select 1
+      from public.user_profile me
+      where me.id = auth.uid()
+        and me.school_id = message_thread.school_id
+    )
+  )
+);
+
+drop policy if exists mt_ins on public.message_thread;
+create policy mt_ins on public.message_thread
+for insert with check (
+  created_by = auth.uid()
+  and (
+    exists (
+      select 1
+      from public.user_profile me
+      where me.id = auth.uid()
+        and me.role = 'director'
+        and me.school_id = message_thread.school_id
+    )
+    or exists (
+      select 1
+      from public.teacher_classroom tc
+      where tc.teacher_id = auth.uid()
+        and tc.classroom_id = message_thread.classroom_id
+    )
+  )
+);
+
+alter table public.message enable row level security;
+drop policy if exists msg_sel on public.message;
+create policy msg_sel on public.message
+for select using (
+  exists (
+    select 1
+    from public.message_thread t
+    where t.id = message.thread_id
+      and (
+        exists (
+          select 1
+          from public.user_profile me
+          where me.id = auth.uid()
+            and me.role = 'director'
+            and me.school_id = t.school_id
+        )
+        or exists (
+          select 1
+          from public.teacher_classroom tc
+          where tc.teacher_id = auth.uid()
+            and tc.classroom_id = t.classroom_id
+        )
+        or exists (
+          select 1
+          from public.guardian g
+          join public.enrollment e on e.student_id = g.student_id
+          where g.user_id = auth.uid()
+            and e.classroom_id = t.classroom_id
+        )
+        or (
+          t.classroom_id is null
+          and exists (
+            select 1
+            from public.user_profile me
+            where me.id = auth.uid()
+              and me.school_id = t.school_id
+          )
+        )
+      )
+  )
+);
+
+drop policy if exists msg_ins on public.message;
+create policy msg_ins on public.message
+for insert with check (
+  sender_id = auth.uid()
+  and exists (
+    select 1
+    from public.message_thread t
+    where t.id = message.thread_id
+      and (
+        exists (
+          select 1
+          from public.user_profile me
+          where me.id = auth.uid()
+            and me.role in ('director', 'maestra', 'teacher')
+            and me.school_id = t.school_id
+        )
+        or exists (
+          select 1
+          from public.teacher_classroom tc
+          where tc.teacher_id = auth.uid()
+            and tc.classroom_id = t.classroom_id
+        )
+        or exists (
+          select 1
+          from public.guardian g
+          join public.enrollment e on e.student_id = g.student_id
+          where g.user_id = auth.uid()
+            and e.classroom_id = t.classroom_id
+        )
+      )
+  )
+);

--- a/types/database.ts
+++ b/types/database.ts
@@ -6,7 +6,7 @@ export type Json =
   | { [key: string]: Json | undefined }
   | Json[];
 
-export interface Database {
+export type Database = {
   public: {
     Tables: {
       attendance: {
@@ -393,4 +393,4 @@ export interface Database {
     Enums: {};
     CompositeTypes: {};
   };
-}
+};

--- a/types/database.ts
+++ b/types/database.ts
@@ -181,6 +181,89 @@ export interface Database {
           }
         ];
       };
+      message: {
+        Row: {
+          body: string;
+          created_at: string;
+          id: string;
+          sender_id: string;
+          thread_id: string;
+        };
+        Insert: {
+          body: string;
+          created_at?: string;
+          id?: string;
+          sender_id: string;
+          thread_id: string;
+        };
+        Update: {
+          body?: string;
+          created_at?: string;
+          id?: string;
+          sender_id?: string;
+          thread_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "message_sender_id_fkey";
+            columns: ["sender_id"];
+            referencedRelation: "user_profile";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "message_thread_id_fkey";
+            columns: ["thread_id"];
+            referencedRelation: "message_thread";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      message_thread: {
+        Row: {
+          classroom_id: string | null;
+          created_at: string;
+          created_by: string;
+          id: string;
+          school_id: string;
+          title: string;
+        };
+        Insert: {
+          classroom_id?: string | null;
+          created_at?: string;
+          created_by: string;
+          id?: string;
+          school_id: string;
+          title: string;
+        };
+        Update: {
+          classroom_id?: string | null;
+          created_at?: string;
+          created_by?: string;
+          id?: string;
+          school_id?: string;
+          title?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "message_thread_classroom_id_fkey";
+            columns: ["classroom_id"];
+            referencedRelation: "classroom";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "message_thread_created_by_fkey";
+            columns: ["created_by"];
+            referencedRelation: "user_profile";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "message_thread_school_id_fkey";
+            columns: ["school_id"];
+            referencedRelation: "school";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       school: {
         Row: {
           created_at: string | null;
@@ -272,23 +355,23 @@ export interface Database {
           created_at: string | null;
           display_name: string | null;
           id: string;
-          role: "director" | "teacher" | "parent";
+          role: "director" | "teacher" | "parent" | "maestra";
           school_id: string | null;
         };
         Insert: {
           created_at?: string | null;
           display_name?: string | null;
           id: string;
-          role?: "director" | "teacher" | "parent";
+          role?: "director" | "teacher" | "parent" | "maestra";
           school_id?: string | null;
         };
-        Update: {
-          created_at?: string | null;
-          display_name?: string | null;
-          id?: string;
-          role?: "director" | "teacher" | "parent";
-          school_id?: string | null;
-        };
+          Update: {
+            created_at?: string | null;
+            display_name?: string | null;
+            id?: string;
+            role?: "director" | "teacher" | "parent" | "maestra";
+            school_id?: string | null;
+          };
         Relationships: [
           {
             foreignKeyName: "user_profile_school_id_fkey";


### PR DESCRIPTION
## Summary
- add SQL script for message threads/messages tables and row level security policies
- implement messages UI to list threads, create new announcements, and reply within a thread
- document setup and extend typings/attendance logic to cover the new module and maestra role

## Testing
- not run `npm run lint` (Next.js prompts for ESLint configuration in this repo)
- not run `npm test` (Supabase CLI is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf5892487c833387f3573b0903d202